### PR TITLE
Fix missing shape appearance style reference

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -31,7 +31,7 @@
                     android:padding="20dp"
                     android:scaleType="centerInside"
                     android:src="@drawable/ic_profile_avatar"
-                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.MaterialComponents.Full"
+                    app:shapeAppearanceOverlay="@style/ShapeAppearanceOverlay.ResortApp.Circle"
                     app:strokeColor="@android:color/white"
                     app:strokeWidth="2dp" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,5 +30,10 @@
         <item name="android:textStyle">bold</item>
     </style>
 
+    <style name="ShapeAppearanceOverlay.ResortApp.Circle" parent="">
+        <item name="cornerFamily">rounded</item>
+        <item name="cornerSize">50%</item>
+    </style>
+
 
 </resources>


### PR DESCRIPTION
## Summary
- replace the ShapeableImageView overlay reference with a project-specific style
- add a circular shape appearance overlay to the shared styles for reuse

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0e0071f3c83218fd8d38432576fa1