### PR TITLE
Switch resort app theme to green palette

### DIFF
--- a/app/src/main/res/drawable/bg_profile_header.xml
+++ b/app/src/main/res/drawable/bg_profile_header.xml
@@ -2,6 +2,6 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
     <gradient
         android:angle="135"
-        android:endColor="@color/purple_accent"
-        android:startColor="@color/purple_dark" />
+        android:endColor="@color/green_accent"
+        android:startColor="@color/green_dark" />
 </shape>

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -18,7 +18,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         app:itemIconSize="24dp"
-        app:itemRippleColor="@color/purple_light"
+        app:itemRippleColor="@color/green_light"
         android:background="@android:color/white"
         app:itemIconTint="@color/bottom_nav_colors"
         app:itemTextColor="@color/bottom_nav_colors"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -70,7 +70,7 @@
                 android:layout_marginBottom="20dp"
                 app:cardCornerRadius="20dp"
                 app:cardUseCompatPadding="false"
-                app:strokeColor="@color/purple_accent"
+                app:strokeColor="@color/green_accent"
                 app:strokeWidth="0.5dp">
 
                 <LinearLayout
@@ -186,7 +186,7 @@
                 android:layout_marginBottom="20dp"
                 app:cardCornerRadius="20dp"
                 app:cardUseCompatPadding="false"
-                app:strokeColor="@color/purple_accent"
+                app:strokeColor="@color/green_accent"
                 app:strokeWidth="0.5dp">
 
                 <LinearLayout

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,8 +2,8 @@
 <resources>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
-    <color name="purple_primary">#673AB7</color>
-    <color name="purple_light">#D1C4E9</color>
-    <color name="purple_dark">#512DA8</color>
-    <color name="purple_accent">#7C4DFF</color>
+    <color name="green_primary">#2E7D32</color>
+    <color name="green_light">#C8E6C9</color>
+    <color name="green_dark">#1B5E20</color>
+    <color name="green_accent">#81C784</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,11 +6,11 @@
 
     <!-- Your chip style -->
     <style name="MyChipStyle" parent="Widget.Material3.Chip.Filter">
-        <item name="chipBackgroundColor">#E8F5E9</item>
-        <item name="chipStrokeColor">#A5D6A7</item>
+        <item name="chipBackgroundColor">@color/green_light</item>
+        <item name="chipStrokeColor">@color/green_accent</item>
         <item name="chipStrokeWidth">1dp</item>
         <!-- optional -->
-        <item name="rippleColor">#C8E6C9</item>
+        <item name="rippleColor">@color/green_light</item>
     </style>
     <!-- Big, comfy assist chips -->
     <style name="Chip.Big" parent="Widget.Material3.Chip.Assist.Elevated">
@@ -20,8 +20,8 @@
         <item name="chipMinHeight">40dp</item>
         <item name="chipCornerRadius">16dp</item>
         <item name="android:textStyle">bold</item>
-        <item name="chipBackgroundColor">@color/purple_light</item>
-        <item name="chipStrokeColor">@color/purple_primary</item>
+        <item name="chipBackgroundColor">@color/green_light</item>
+        <item name="chipStrokeColor">@color/green_primary</item>
         <item name="chipStrokeWidth">1dp</item>
     </style>
 


### PR DESCRIPTION
## Summary
- replace the purple color resources with a light green palette that aligns with the eco-friendly theme
- update chip styles, profile cards, navigation ripple, and header gradient to use the refreshed colors

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e1b00db48321b7a7cbd1f73219b9