### PR TITLE
Update Material theme to green palette

### DIFF
--- a/app/src/main/res/layout/item_booking.xml
+++ b/app/src/main/res/layout/item_booking.xml
@@ -44,7 +44,7 @@
 
             <TextView
                 android:id="@+id/tvStatus"
-                android:textColor="#7C4DFF"
+                android:textColor="@color/green_primary"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"/>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,7 +1,23 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.ResortApp" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your dark theme here. -->
-        <!-- <item name="colorPrimary">@color/my_dark_primary</item> -->
+        <item name="colorPrimary">@color/green_accent</item>
+        <item name="colorOnPrimary">@color/green_dark</item>
+        <item name="colorPrimaryContainer">@color/green_dark</item>
+        <item name="colorOnPrimaryContainer">@color/green_light</item>
+        <item name="colorSecondary">@color/green_primary</item>
+        <item name="colorOnSecondary">@color/white</item>
+        <item name="colorSecondaryContainer">@color/green_dark</item>
+        <item name="colorOnSecondaryContainer">@color/green_light</item>
+        <item name="colorTertiary">@color/green_primary</item>
+        <item name="colorOnTertiary">@color/white</item>
+        <item name="colorTertiaryContainer">@color/green_dark</item>
+        <item name="colorOnTertiaryContainer">@color/green_light</item>
+        <item name="colorSurface">@color/green_dark</item>
+        <item name="colorOnSurface">@color/green_light</item>
+        <item name="colorSurfaceVariant">@color/green_primary</item>
+        <item name="colorOnSurfaceVariant">@color/green_light</item>
+        <item name="colorOutline">@color/green_accent</item>
+        <item name="colorPrimaryInverse">@color/green_light</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,8 +1,24 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <style name="Base.Theme.ResortApp" parent="Theme.Material3.DayNight.NoActionBar">
-        <!-- Customize your light theme here. -->
-        <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+        <item name="colorPrimary">@color/green_primary</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorPrimaryContainer">@color/green_light</item>
+        <item name="colorOnPrimaryContainer">@color/green_dark</item>
+        <item name="colorSecondary">@color/green_accent</item>
+        <item name="colorOnSecondary">@color/green_dark</item>
+        <item name="colorSecondaryContainer">@color/green_light</item>
+        <item name="colorOnSecondaryContainer">@color/green_dark</item>
+        <item name="colorTertiary">@color/green_accent</item>
+        <item name="colorOnTertiary">@color/green_dark</item>
+        <item name="colorTertiaryContainer">@color/green_light</item>
+        <item name="colorOnTertiaryContainer">@color/green_dark</item>
+        <item name="colorSurface">@color/white</item>
+        <item name="colorOnSurface">@color/green_dark</item>
+        <item name="colorSurfaceVariant">@color/green_light</item>
+        <item name="colorOnSurfaceVariant">@color/green_dark</item>
+        <item name="colorOutline">@color/green_primary</item>
+        <item name="colorPrimaryInverse">@color/green_dark</item>
     </style>
 
     <style name="Theme.ResortApp" parent="Base.Theme.ResortApp" />


### PR DESCRIPTION
## Summary
- set the Material theme color palette to use the existing green tones in both light and dark modes
- update the booking status text color to use the shared green primary color instead of a hardcoded purple value

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e2d0a7188321946234e5040e440a