### PR TITLE
Enhance authentication forms with modern styling and inline errors

### DIFF
--- a/app/src/main/java/com/example/resortapp/LoginActivity.java
+++ b/app/src/main/java/com/example/resortapp/LoginActivity.java
@@ -1,12 +1,19 @@
 package com.example.resortapp;
 
-
-
 import android.content.Intent;
 import android.os.Bundle;
-import android.widget.*;
+import android.util.Patterns;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseAuthInvalidCredentialsException;
+import com.google.firebase.auth.FirebaseAuthInvalidUserException;
 
 public class LoginActivity extends AppCompatActivity {
     private EditText etEmail, etPassword;
@@ -14,15 +21,18 @@ public class LoginActivity extends AppCompatActivity {
     private TextView tvGoRegister;
     private FirebaseAuth auth;
     private TextView tvForgot;
+    private TextInputLayout tilEmail, tilPassword;
 
-    @Override protected void onCreate(Bundle savedInstanceState) {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
         auth = FirebaseAuth.getInstance();
 
         if (auth.getCurrentUser() != null) {
             startActivity(new Intent(this, DashboardActivity.class));
-            finish(); return;
+            finish();
+            return;
         }
 
         etEmail = findViewById(R.id.etEmail);
@@ -30,6 +40,8 @@ public class LoginActivity extends AppCompatActivity {
         btnLogin = findViewById(R.id.btnLogin);
         tvGoRegister = findViewById(R.id.tvGoRegister);
         tvForgot = findViewById(R.id.tvForgot);
+        tilEmail = findViewById(R.id.tilEmail);
+        tilPassword = findViewById(R.id.tilPassword);
 
         btnLogin.setOnClickListener(v -> login());
         tvGoRegister.setOnClickListener(v -> startActivity(new Intent(this, RegisterActivity.class)));
@@ -39,11 +51,29 @@ public class LoginActivity extends AppCompatActivity {
 
     private void login() {
         String email = etEmail.getText().toString().trim();
-        String pass  = etPassword.getText().toString();
+        String pass = etPassword.getText().toString();
 
-        if (email.isEmpty() || pass.isEmpty()) {
-            Toast.makeText(this, "Enter email & password", Toast.LENGTH_SHORT).show(); return;
+        tilEmail.setError(null);
+        tilPassword.setError(null);
+
+        if (email.isEmpty()) {
+            tilEmail.setError("Email is required");
+            tilEmail.requestFocus();
+            return;
         }
+
+        if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            tilEmail.setError("Enter a valid email");
+            tilEmail.requestFocus();
+            return;
+        }
+
+        if (pass.isEmpty()) {
+            tilPassword.setError("Password is required");
+            tilPassword.requestFocus();
+            return;
+        }
+
         btnLogin.setEnabled(false);
         auth.signInWithEmailAndPassword(email, pass)
                 .addOnSuccessListener(result -> {
@@ -51,7 +81,12 @@ public class LoginActivity extends AppCompatActivity {
                     finish();
                 })
                 .addOnFailureListener(e -> {
-                    Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                    if (e instanceof FirebaseAuthInvalidCredentialsException || e instanceof FirebaseAuthInvalidUserException) {
+                        tilPassword.setError("Incorrect email or password");
+                        tilPassword.requestFocus();
+                    } else {
+                        Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                    }
                     btnLogin.setEnabled(true);
                 });
     }

--- a/app/src/main/java/com/example/resortapp/ResetPasswordActivity.java
+++ b/app/src/main/java/com/example/resortapp/ResetPasswordActivity.java
@@ -3,8 +3,14 @@ package com.example.resortapp;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Patterns;
-import android.widget.*;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.TextView;
+import android.widget.Toast;
+
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.auth.FirebaseAuth;
 
 public class ResetPasswordActivity extends AppCompatActivity {
@@ -13,14 +19,17 @@ public class ResetPasswordActivity extends AppCompatActivity {
     private Button btnSend;
     private TextView tvBack;
     private FirebaseAuth auth;
+    private TextInputLayout tilEmail;
 
-    @Override protected void onCreate(Bundle savedInstanceState) {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_reset_password);
 
         etEmail = findViewById(R.id.etEmail);
         btnSend = findViewById(R.id.btnSend);
         tvBack  = findViewById(R.id.tvBack);
+        tilEmail = findViewById(R.id.tilEmail);
         auth = FirebaseAuth.getInstance();
 
         btnSend.setOnClickListener(v -> sendReset());
@@ -30,8 +39,17 @@ public class ResetPasswordActivity extends AppCompatActivity {
     private void sendReset() {
         String email = etEmail.getText().toString().trim();
 
-        if (TextUtils.isEmpty(email) || !Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
-            Toast.makeText(this, "Enter a valid email", Toast.LENGTH_SHORT).show();
+        tilEmail.setError(null);
+
+        if (TextUtils.isEmpty(email)) {
+            tilEmail.setError("Email is required");
+            tilEmail.requestFocus();
+            return;
+        }
+
+        if (!Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            tilEmail.setError("Enter a valid email address");
+            tilEmail.requestFocus();
             return;
         }
 
@@ -44,11 +62,12 @@ public class ResetPasswordActivity extends AppCompatActivity {
                 })
                 .addOnFailureListener(e -> {
                     String msg = e.getMessage();
-                    // Friendly messages for common cases
                     if (msg != null && msg.toLowerCase().contains("no user record")) {
-                        msg = "No account found for this email.";
+                        tilEmail.setError("No account found for this email.");
+                        tilEmail.requestFocus();
+                    } else {
+                        Toast.makeText(this, msg != null ? msg : "Failed to send reset email", Toast.LENGTH_LONG).show();
                     }
-                    Toast.makeText(this, msg != null ? msg : "Failed to send reset email", Toast.LENGTH_LONG).show();
                     btnSend.setEnabled(true);
                 });
     }

--- a/app/src/main/res/drawable/ic_bed.xml
+++ b/app/src/main/res/drawable/ic_bed.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M19,7A2,2 0,0 0,17 9V12H5V6H3V20H5V16H19V20H21V13A2,2 0,0 0,19 11H9V9A2,2 0,0 1,11 7Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_email.xml
+++ b/app/src/main/res/drawable/ic_email.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M20,4H4A2,2 0,0 0,2 6V18A2,2 0,0 0,4 20H20A2,2 0,0 0,22 18V6A2,2 0,0 0,20 4ZM20,8L12,13L4,8V6L12,11L20,6Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_lock.xml
+++ b/app/src/main/res/drawable/ic_lock.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M17,8H16V6A4,4 0,0 0,8 6V8H7A2,2 0,0 0,5 10V20A2,2 0,0 0,7 22H17A2,2 0,0 0,19 20V10A2,2 0,0 0,17 8ZM12,17A2,2 0,1 1,14 15A2,2 0,0 1,12 17ZM10,8V6A2,2 0,0 1,14 6V8Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_person.xml
+++ b/app/src/main/res/drawable/ic_person.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12,12A4,4 0,1 0,8 8A4,4 0,0 0,12 12ZM12,14C9.33,14 4,15.34 4,18V20H20V18C20,15.34 14.67,14 12,14Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_phone.xml
+++ b/app/src/main/res/drawable/ic_phone.xml
@@ -1,10 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="#FF000000"
-        android:pathData="M6.62,10.79c1.44,2.83 3.76,5.14 6.59,6.59l2.2,-2.2c0.27,-0.27 0.67,-0.36 1.02,-0.24 1.12,0.37 2.33,0.57 3.57,0.57 0.55,0 1,0.45 1,1v3.5c0,0.55 -0.45,1 -1,1C10.07,21 3,13.93 3,5c0,-0.55 0.45,-1 1,-1H7.5c0.55,0 1,0.45 1,1 0,1.24 0.2,2.45 0.57,3.57 0.11,0.35 0.03,0.74 -0.25,1.02l-2.2,2.2z" />
+        android:fillColor="@android:color/black"
+        android:pathData="M6.62,10.79C8.06,13.62 10.38,15.94 13.21,17.38L15.41,15.18A1,1 0,0 1,16.32 14.92A10.66,10.66 0,0 0,18.68 15.45A1,1 0,0 1,19.5 16.45V20A1,1 0,0 1,18.5 21A16.5,16.5 0,0 1,3 5.5A1,1 0,0 1,4 4.5H7.55A1,1 0,0 1,8.55 5.32A10.66,10.66 0,0 0,9.08 7.68A1,1 0,0 1,8.82 8.59Z" />
 </vector>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -37,8 +37,11 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="32dp"
+        app:cardBackgroundColor="@android:color/white"
         app:cardCornerRadius="28dp"
-        app:cardElevation="12dp"
+        app:cardElevation="6dp"
+        app:strokeColor="@color/green_light"
+        app:strokeWidth="1dp"
         app:cardUseCompatPadding="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -60,42 +63,39 @@
                 android:textStyle="bold" />
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilEmail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:hint="Email"
-                app:boxBackgroundMode="filled"
-                app:boxCornerRadiusTopEnd="16dp"
-                app:boxCornerRadiusTopStart="16dp"
-                app:boxCornerRadiusBottomEnd="16dp"
-                app:boxCornerRadiusBottomStart="16dp"
-                app:boxStrokeColor="@color/green_light"
-                app:hintTextColor="@color/green_dark">
+                style="@style/Widget.ResortApp.TextInputLayout"
+                app:startIconDrawable="@drawable/ic_email">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/etEmail"
+                    style="@style/Widget.ResortApp.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:imeOptions="actionNext"
                     android:inputType="textEmailAddress" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilPassword"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
                 android:hint="Password"
-                app:boxBackgroundMode="filled"
-                app:boxCornerRadiusTopEnd="16dp"
-                app:boxCornerRadiusTopStart="16dp"
-                app:boxCornerRadiusBottomEnd="16dp"
-                app:boxCornerRadiusBottomStart="16dp"
-                app:boxStrokeColor="@color/green_light"
-                app:hintTextColor="@color/green_dark">
+                style="@style/Widget.ResortApp.TextInputLayout"
+                app:endIconMode="password_toggle"
+                app:startIconDrawable="@drawable/ic_lock">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/etPassword"
+                    style="@style/Widget.ResortApp.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
                     android:inputType="textPassword" />
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -111,12 +111,12 @@
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnLogin"
-                style="@style/Widget.MaterialComponents.Button"
+                style="@style/Widget.ResortApp.PrimaryButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
+                android:elevation="0dp"
                 android:text="Login"
-                app:cornerRadius="16dp"
                 app:iconGravity="textStart"
                 app:rippleColor="@color/green_accent" />
 

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -37,8 +37,11 @@
         android:layout_height="0dp"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="16dp"
+        app:cardBackgroundColor="@android:color/white"
         app:cardCornerRadius="28dp"
-        app:cardElevation="12dp"
+        app:cardElevation="6dp"
+        app:strokeColor="@color/green_light"
+        app:strokeWidth="1dp"
         app:cardUseCompatPadding="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -65,99 +68,88 @@
                     android:textStyle="bold" />
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilName"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
                     android:hint="Full name"
-                    app:boxBackgroundMode="filled"
-                    app:boxCornerRadiusBottomEnd="16dp"
-                    app:boxCornerRadiusBottomStart="16dp"
-                    app:boxCornerRadiusTopEnd="16dp"
-                    app:boxCornerRadiusTopStart="16dp"
-                    app:boxStrokeColor="@color/green_light"
-                    app:hintTextColor="@color/green_dark">
+                    style="@style/Widget.ResortApp.TextInputLayout"
+                    app:startIconDrawable="@drawable/ic_person">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/etName"
+                        style="@style/Widget.ResortApp.TextInputEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilEmail"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:hint="Email"
-                    app:boxBackgroundMode="filled"
-                    app:boxCornerRadiusBottomEnd="16dp"
-                    app:boxCornerRadiusBottomStart="16dp"
-                    app:boxCornerRadiusTopEnd="16dp"
-                    app:boxCornerRadiusTopStart="16dp"
-                    app:boxStrokeColor="@color/green_light"
-                    app:hintTextColor="@color/green_dark">
+                    style="@style/Widget.ResortApp.TextInputLayout"
+                    app:startIconDrawable="@drawable/ic_email">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/etEmail"
+                        style="@style/Widget.ResortApp.TextInputEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:imeOptions="actionNext"
                         android:inputType="textEmailAddress" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilPhone"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:hint="Phone (optional)"
-                    app:boxBackgroundMode="filled"
-                    app:boxCornerRadiusBottomEnd="16dp"
-                    app:boxCornerRadiusBottomStart="16dp"
-                    app:boxCornerRadiusTopEnd="16dp"
-                    app:boxCornerRadiusTopStart="16dp"
-                    app:boxStrokeColor="@color/green_light"
-                    app:hintTextColor="@color/green_dark">
+                    style="@style/Widget.ResortApp.TextInputLayout"
+                    app:startIconDrawable="@drawable/ic_phone">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/etPhone"
+                        style="@style/Widget.ResortApp.TextInputEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:inputType="phone" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilPassword"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:hint="Password"
-                    app:boxBackgroundMode="filled"
-                    app:boxCornerRadiusBottomEnd="16dp"
-                    app:boxCornerRadiusBottomStart="16dp"
-                    app:boxCornerRadiusTopEnd="16dp"
-                    app:boxCornerRadiusTopStart="16dp"
-                    app:boxStrokeColor="@color/green_light"
-                    app:hintTextColor="@color/green_dark">
+                    style="@style/Widget.ResortApp.TextInputLayout"
+                    app:endIconMode="password_toggle"
+                    app:startIconDrawable="@drawable/ic_lock">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/etPassword"
+                        style="@style/Widget.ResortApp.TextInputEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:imeOptions="actionNext"
                         android:inputType="textPassword" />
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilPreference"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="12dp"
                     android:hint="Room preference"
-                    app:boxBackgroundMode="filled"
-                    app:boxCornerRadiusBottomEnd="16dp"
-                    app:boxCornerRadiusBottomStart="16dp"
-                    app:boxCornerRadiusTopEnd="16dp"
-                    app:boxCornerRadiusTopStart="16dp"
-                    app:boxStrokeColor="@color/green_light"
-                    app:hintTextColor="@color/green_dark">
+                    style="@style/Widget.ResortApp.TextInputLayout"
+                    app:endIconMode="dropdown_menu"
+                    app:startIconDrawable="@drawable/ic_bed">
 
-                    <AutoCompleteTextView
+                    <com.google.android.material.textfield.MaterialAutoCompleteTextView
                         android:id="@+id/etPreference"
+                        style="@style/Widget.ResortApp.TextInputEditText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:focusable="false"
@@ -166,12 +158,12 @@
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/btnRegister"
-                    style="@style/Widget.MaterialComponents.Button"
+                    style="@style/Widget.ResortApp.PrimaryButton"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
+                    android:elevation="0dp"
                     android:text="Sign up"
-                    app:cornerRadius="16dp"
                     app:iconGravity="textStart"
                     app:rippleColor="@color/green_accent" />
 

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -37,8 +37,11 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="24dp"
         android:layout_marginBottom="32dp"
+        app:cardBackgroundColor="@android:color/white"
         app:cardCornerRadius="28dp"
-        app:cardElevation="12dp"
+        app:cardElevation="6dp"
+        app:strokeColor="@color/green_light"
+        app:strokeWidth="1dp"
         app:cardUseCompatPadding="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -60,33 +63,31 @@
                 android:textStyle="bold" />
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilEmail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:hint="Email"
-                app:boxBackgroundMode="filled"
-                app:boxCornerRadiusBottomEnd="16dp"
-                app:boxCornerRadiusBottomStart="16dp"
-                app:boxCornerRadiusTopEnd="16dp"
-                app:boxCornerRadiusTopStart="16dp"
-                app:boxStrokeColor="@color/green_light"
-                app:hintTextColor="@color/green_dark">
+                style="@style/Widget.ResortApp.TextInputLayout"
+                app:startIconDrawable="@drawable/ic_email">
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/etEmail"
+                    style="@style/Widget.ResortApp.TextInputEditText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
                     android:inputType="textEmailAddress" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnSend"
-                style="@style/Widget.MaterialComponents.Button"
+                style="@style/Widget.ResortApp.PrimaryButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
+                android:elevation="0dp"
                 android:text="Send reset link"
-                app:cornerRadius="16dp"
                 app:iconGravity="textStart"
                 app:rippleColor="@color/green_accent" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,4 +36,33 @@
     </style>
 
 
+    <style name="Widget.ResortApp.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense">
+        <item name="boxBackgroundColor">@android:color/white</item>
+        <item name="boxStrokeColor">@color/green_primary</item>
+        <item name="boxStrokeWidth">1dp</item>
+        <item name="boxStrokeWidthFocused">2dp</item>
+        <item name="boxCornerRadiusTopStart">18dp</item>
+        <item name="boxCornerRadiusTopEnd">18dp</item>
+        <item name="boxCornerRadiusBottomStart">18dp</item>
+        <item name="boxCornerRadiusBottomEnd">18dp</item>
+        <item name="hintTextColor">@color/green_dark</item>
+        <item name="startIconTint">@color/green_primary</item>
+        <item name="android:textColorHint">@color/green_dark</item>
+    </style>
+
+    <style name="Widget.ResortApp.TextInputEditText" parent="Widget.MaterialComponents.TextInputEditText.FilledBox.Dense">
+        <item name="android:textColor">@color/green_dark</item>
+        <item name="android:textSize">16sp</item>
+        <item name="android:paddingTop">12dp</item>
+        <item name="android:paddingBottom">12dp</item>
+    </style>
+
+    <style name="Widget.ResortApp.PrimaryButton" parent="Widget.MaterialComponents.Button">
+        <item name="backgroundTint">@color/green_primary</item>
+        <item name="cornerRadius">18dp</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:letterSpacing">0.05</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
## Summary
- refresh the login, register, and reset password screens with card styling, start icons, and consistent Material text fields/buttons
- surface inline validation through TextInputLayout errors across authentication flows instead of relying on toasts
- add reusable styles and vector assets to support the updated UI aesthetics

## Testing
- ./gradlew assembleDebug *(fails: Android SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e9d797388321b7d4fd2cec5a14f7