### PR TITLE
Adjust text input styling to prevent hint overlap

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -53,8 +53,9 @@
     <style name="Widget.ResortApp.TextInputEditText" parent="Widget.MaterialComponents.TextInputEditText.FilledBox.Dense">
         <item name="android:textColor">@color/green_dark</item>
         <item name="android:textSize">16sp</item>
-        <item name="android:paddingTop">12dp</item>
-        <item name="android:paddingBottom">12dp</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
     </style>
 
     <style name="Widget.ResortApp.PrimaryButton" parent="Widget.MaterialComponents.Button">


### PR DESCRIPTION
## Summary
- center the text vertically within custom TextInputEditText styling
- remove the additional top and bottom padding that forced the hint text to overlap with user input

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ec541458832180a8881ad2bf6187