### PR TITLE
Switch text input widgets to Material 3 styles

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,7 +36,7 @@
     </style>
 
 
-    <style name="Widget.ResortApp.TextInputLayout" parent="Widget.MaterialComponents.TextInputLayout.FilledBox.Dense">
+    <style name="Widget.ResortApp.TextInputLayout" parent="Widget.Material3.TextInputLayout.FilledBox.Dense">
         <item name="boxBackgroundColor">@android:color/white</item>
         <item name="boxStrokeColor">@color/green_primary</item>
         <item name="boxStrokeWidth">1dp</item>
@@ -50,11 +50,12 @@
         <item name="android:textColorHint">@color/green_dark</item>
     </style>
 
-    <style name="Widget.ResortApp.TextInputEditText" parent="Widget.MaterialComponents.TextInputEditText.FilledBox.Dense">
+    <style name="Widget.ResortApp.TextInputEditText" parent="Widget.Material3.TextInputEditText.FilledBox.Dense">
         <item name="android:textColor">@color/green_dark</item>
         <item name="android:textSize">16sp</item>
-        <item name="android:paddingTop">12dp</item>
-        <item name="android:paddingBottom">12dp</item>
+        <item name="android:gravity">center_vertical</item>
+        <item name="android:paddingTop">0dp</item>
+        <item name="android:paddingBottom">0dp</item>
     </style>
 
     <style name="Widget.ResortApp.PrimaryButton" parent="Widget.MaterialComponents.Button">


### PR DESCRIPTION
## Summary
- switch the custom TextInputLayout and TextInputEditText styles to the Material 3 filled-box variants so floating hints render correctly

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ec541458832180a8881ad2bf6187