### PR TITLE
Add Material top app bars to activities and eco highlights screens

### DIFF
--- a/app/src/main/java/com/example/resortapp/ActivitiesListActivity.java
+++ b/app/src/main/java/com/example/resortapp/ActivitiesListActivity.java
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.resortapp.model.Room;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.firebase.firestore.*;
 
 import java.lang.reflect.Field;
@@ -21,6 +22,10 @@ public class ActivitiesListActivity extends AppCompatActivity {
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_activities_list);
+
+        MaterialToolbar bar = findViewById(R.id.topAppBar);
+        setSupportActionBar(bar);
+        bar.setNavigationOnClickListener(v -> getOnBackPressedDispatcher().onBackPressed());
 
         RecyclerView rv = findViewById(R.id.rvAllActivities);
         rv.setLayoutManager(new LinearLayoutManager(this));

--- a/app/src/main/java/com/example/resortapp/EcoInfoListActivity.java
+++ b/app/src/main/java/com/example/resortapp/EcoInfoListActivity.java
@@ -9,6 +9,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.example.resortapp.model.EcoInfo;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.firebase.firestore.*;
 
 import java.util.*;
@@ -22,6 +23,10 @@ public class EcoInfoListActivity extends AppCompatActivity {
     @Override protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_eco_info_list);
+
+        MaterialToolbar bar = findViewById(R.id.topAppBar);
+        setSupportActionBar(bar);
+        bar.setNavigationOnClickListener(v -> getOnBackPressedDispatcher().onBackPressed());
 
         // find views
         rvInitiatives = findViewById(R.id.rvInitiatives);

--- a/app/src/main/res/layout/activity_activities_list.xml
+++ b/app/src/main/res/layout/activity_activities_list.xml
@@ -1,10 +1,29 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent" android:layout_height="match_parent">
-    <TextView android:id="@+id/tvTitle" android:text="Activities"
-        android:textStyle="bold" android:textSize="20sp"
-        android:padding="16dp" android:layout_width="match_parent" android:layout_height="wrap_content"/>
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorSurface"
+        app:title="Activities"
+        app:navigationIcon="@drawable/abc_ic_ab_back_material" />
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Activities"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvAllActivities"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="match_parent" />
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_eco_info_list.xml
+++ b/app/src/main/res/layout/activity_eco_info_list.xml
@@ -1,13 +1,27 @@
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/ecoScroll"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:orientation="vertical">
 
-    <LinearLayout
-        android:orientation="vertical"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/topAppBar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorSurface"
+        app:title="Eco Highlights"
+        app:navigationIcon="@drawable/abc_ic_ab_back_material" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/ecoScroll"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <!-- Title -->
         <TextView
@@ -78,5 +92,7 @@
         <Space
             android:layout_width="match_parent"
             android:layout_height="24dp"/>
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add a Material top app bar with back navigation to the activities list screen
- add a Material top app bar with back navigation to the eco highlights screen

## Testing
- ./gradlew lint --quiet *(fails: missing Android SDK in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e13955a784832198a7454d6465cf54