### PR TITLE
Align activities and eco highlights carousels on home screen

### DIFF
--- a/app/src/main/java/com/example/resortapp/HomeFragment.java
+++ b/app/src/main/java/com/example/resortapp/HomeFragment.java
@@ -57,13 +57,18 @@ public class HomeFragment extends Fragment {
             ((androidx.recyclerview.widget.DefaultItemAnimator) ia).setSupportsChangeAnimations(false);
         }
 
-        adapter = new RoomListAdapter();
+        adapter = new RoomListAdapter(RoomListAdapter.LayoutMode.CARD);
         rv.setAdapter(adapter);
+        adapter.setOnRoomClick(room -> {
+            Intent i = new Intent(requireContext(), RoomDetailActivity.class);
+            i.putExtra("roomId", room.getId());
+            startActivity(i);
+        });
 
         // --- in onCreateView after Rooms setup:
         rvActivities = v.findViewById(R.id.rvActivities);
         rvActivities.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
-        activitiesAdapter = new RoomListAdapter(); // it binds name/img/price; description can be empty
+        activitiesAdapter = new RoomListAdapter(RoomListAdapter.LayoutMode.CARD); // it binds name/img/price; description can be empty
         rvActivities.setAdapter(activitiesAdapter);
 
 

--- a/app/src/main/java/com/example/resortapp/RoomListAdapter.java
+++ b/app/src/main/java/com/example/resortapp/RoomListAdapter.java
@@ -20,11 +20,17 @@ import java.util.Objects;
 
 public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
 
+    public enum LayoutMode {
+        LIST,
+        CARD
+    }
+
     public interface OnRoomClick {
         void onClick(Room room);
     }
 
     private final List<Room> items = new ArrayList<>();
+    private final LayoutMode layoutMode;
     private OnRoomClick onRoomClick;
 
     public void setOnRoomClick(OnRoomClick cb) {
@@ -32,6 +38,11 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
     }
 
     public RoomListAdapter() {
+        this(LayoutMode.LIST);
+    }
+
+    public RoomListAdapter(LayoutMode layoutMode) {
+        this.layoutMode = layoutMode;
         setHasStableIds(true);
     }
 
@@ -52,11 +63,10 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
     @NonNull
     @Override
     public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-//        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_room_card, parent, false);
-//        return new VH(v);
-
-        View v = LayoutInflater.from(parent.getContext())
-                .inflate(R.layout.item_room_list, parent, false);
+        int layout = layoutMode == LayoutMode.CARD
+                ? R.layout.item_room_card
+                : R.layout.item_room_list;
+        View v = LayoutInflater.from(parent.getContext()).inflate(layout, parent, false);
         return new VH(v);
     }
 
@@ -64,7 +74,11 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
     public void onBindViewHolder(@NonNull VH h, int position) {
         Room r = items.get(position);
         h.name.setText(r.getName() != null ? r.getName() : r.getType());
-        h.desc.setText(r.getDescription());
+        if (h.desc != null) {
+            h.desc.setText(r.getDescription());
+            h.desc.setVisibility(r.getDescription() != null && !r.getDescription().isEmpty()
+                    ? View.VISIBLE : View.GONE);
+        }
         double price = r.getBasePrice() == null ? 0.0 : r.getBasePrice();
         h.price.setText(String.format("LKR %.0f / night", price));
         Glide.with(h.img.getContext()).load(r.getImageUrl()).into(h.img);
@@ -73,7 +87,9 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
             if (onRoomClick != null) onRoomClick.onClick(r);
         };
         h.itemView.setOnClickListener(go);
-        h.btnView.setOnClickListener(go);
+        if (h.btnView != null) {
+            h.btnView.setOnClickListener(go);
+        }
 
 
 //        h.name.setText(r.getName() != null ? r.getName() : r.getType());

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -61,160 +61,127 @@
         </com.google.android.material.card.MaterialCardView>
 
         <!-- Rooms Section -->
-        <com.google.android.material.card.MaterialCardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:clipToPadding="false"
-            app:cardBackgroundColor="@color/dashboard_card_surface"
-            app:cardCornerRadius="20dp"
-            app:cardElevation="8dp"
-            app:cardUseCompatPadding="true">
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="20dp">
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="4dp">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="Rooms for You"
+                    android:textColor="@color/dashboard_title"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-                    <TextView
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Rooms for You"
-                        android:textColor="@color/dashboard_title"
-                        android:textSize="18sp"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/tvSeeMore"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="See more"
-                        android:textColor="@color/dashboard_cta"
-                        android:textStyle="bold" />
-                </LinearLayout>
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rvRooms"
-                    android:layout_width="match_parent"
-                    android:layout_height="220dp"
-                    android:layout_marginTop="12dp"
-                    android:nestedScrollingEnabled="false" />
-
+                <TextView
+                    android:id="@+id/tvSeeMore"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="See more"
+                    android:textColor="@color/dashboard_cta"
+                    android:textStyle="bold" />
             </LinearLayout>
 
-        </com.google.android.material.card.MaterialCardView>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvRooms"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:nestedScrollingEnabled="false" />
+
+        </LinearLayout>
 
         <!-- Activities Section -->
-        <com.google.android.material.card.MaterialCardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:clipToPadding="false"
-            app:cardBackgroundColor="@color/dashboard_card_surface"
-            app:cardCornerRadius="20dp"
-            app:cardElevation="8dp"
-            app:cardUseCompatPadding="true">
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="20dp">
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="4dp">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="Activities"
+                    android:textColor="@color/dashboard_title"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-                    <TextView
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Activities"
-                        android:textColor="@color/dashboard_title"
-                        android:textSize="18sp"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/tvSeeMoreActivities"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="See more"
-                        android:textColor="@color/dashboard_cta"
-                        android:textStyle="bold" />
-                </LinearLayout>
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rvActivities"
-                    android:layout_width="match_parent"
-                    android:layout_height="210dp"
-                    android:layout_marginTop="12dp"
-                    android:nestedScrollingEnabled="false" />
-
+                <TextView
+                    android:id="@+id/tvSeeMoreActivities"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="See more"
+                    android:textColor="@color/dashboard_cta"
+                    android:textStyle="bold" />
             </LinearLayout>
 
-        </com.google.android.material.card.MaterialCardView>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvActivities"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:nestedScrollingEnabled="false" />
+
+        </LinearLayout>
 
         <!-- Eco Highlights Section -->
-        <com.google.android.material.card.MaterialCardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="20dp"
-            android:clipToPadding="false"
-            app:cardBackgroundColor="@color/dashboard_card_surface"
-            app:cardCornerRadius="20dp"
-            app:cardElevation="8dp"
-            app:cardUseCompatPadding="true">
+            android:layout_marginBottom="24dp"
+            android:orientation="vertical">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:padding="20dp">
+                android:gravity="center_vertical"
+                android:orientation="horizontal"
+                android:paddingHorizontal="4dp">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <TextView
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:orientation="horizontal">
+                    android:layout_weight="1"
+                    android:text="Eco Highlights"
+                    android:textColor="@color/dashboard_title"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
 
-                    <TextView
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:text="Eco Highlights"
-                        android:textColor="@color/dashboard_title"
-                        android:textSize="18sp"
-                        android:textStyle="bold" />
-
-                    <TextView
-                        android:id="@+id/tvSeeMoreEco"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="See more"
-                        android:textColor="@color/dashboard_cta"
-                        android:textStyle="bold" />
-                </LinearLayout>
-
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/rvEcoInfo"
-                    android:layout_width="match_parent"
-                    android:layout_height="210dp"
-                    android:layout_marginTop="12dp"
-                    android:nestedScrollingEnabled="false" />
-
+                <TextView
+                    android:id="@+id/tvSeeMoreEco"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="See more"
+                    android:textColor="@color/dashboard_cta"
+                    android:textStyle="bold" />
             </LinearLayout>
 
-        </com.google.android.material.card.MaterialCardView>
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvEcoInfo"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:nestedScrollingEnabled="false" />
+
+        </LinearLayout>
 
         <!-- bottom padding so last row is not hidden behind bottom nav -->
         <Space

--- a/app/src/main/res/layout/item_room_card.xml
+++ b/app/src/main/res/layout/item_room_card.xml
@@ -1,21 +1,25 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="260dp"
-    android:layout_height="200dp"
+    android:layout_height="wrap_content"
     android:layout_marginEnd="12dp"
+    android:layout_marginRight="12dp"
     android:clickable="true"
     android:focusable="true"
-    android:foreground="?attr/selectableItemBackground">
+    android:foreground="?attr/selectableItemBackground"
+    app:cardCornerRadius="18dp"
+    app:cardElevation="6dp">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical">
 
         <ImageView
-            android:id="@+id/imgRoom"
+            android:id="@+id/img"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
+            android:layout_height="150dp"
+            android:contentDescription="@string/app_name"
             android:scaleType="centerCrop" />
 
         <LinearLayout
@@ -30,15 +34,28 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:maxLines="1"
+                android:textColor="@android:color/black"
                 android:textSize="16sp"
                 android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:ellipsize="end"
+                android:maxLines="2"
+                android:textColor="@android:color/darker_gray"
+                android:textSize="13sp" />
 
             <TextView
                 android:id="@+id/tvPrice"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="#666"
-                android:textSize="14sp" />
+                android:layout_marginTop="8dp"
+                android:textColor="@android:color/black"
+                android:textSize="14sp"
+                android:textStyle="bold" />
         </LinearLayout>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- replace the Activities and Eco Highlights cards on the home screen with the new header plus horizontal carousel layout
- keep section actions while allowing the recyclers to reuse the updated room and eco card presentations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e137695a008321a514254422e73552