### PR TITLE
Add reusable logout helper and confirmation dialog

### DIFF
--- a/app/src/main/java/com/example/resortapp/ProfileFragment.java
+++ b/app/src/main/java/com/example/resortapp/ProfileFragment.java
@@ -1,8 +1,6 @@
 package com.example.resortapp;
 
 
-import android.app.AlertDialog;
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.*; import android.widget.*;
 import androidx.annotation.*; import androidx.fragment.app.Fragment;
@@ -17,6 +15,9 @@ import com.google.firebase.firestore.*;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.example.resortapp.util.AuthUtils;
 
 public class ProfileFragment extends Fragment {
 
@@ -80,20 +81,12 @@ public class ProfileFragment extends Fragment {
     }
 
     private void confirmAndLogout() {
-        new AlertDialog.Builder(requireContext())
-                .setTitle("Log out")
-                .setMessage("Are you sure you want to log out?")
-                .setPositiveButton("Log out", (d, which) -> {
-                    FirebaseAuth.getInstance().signOut();
-
-                    // If you also had Google Sign-In, you would signOut() there too.
-
-                    // Go to Login and clear back stack so user can't return with Back
-                    Intent i = new Intent(requireContext(), LoginActivity.class);
-                    i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                    startActivity(i);
-                })
-                .setNegativeButton("Cancel", null)
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.logout_title)
+                .setMessage(R.string.logout_message)
+                .setPositiveButton(R.string.logout_positive, (d, which) ->
+                        AuthUtils.signOut(requireActivity()))
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/example/resortapp/util/AuthUtils.java
+++ b/app/src/main/java/com/example/resortapp/util/AuthUtils.java
@@ -1,0 +1,29 @@
+package com.example.resortapp.util;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import com.example.resortapp.LoginActivity;
+import com.google.firebase.auth.FirebaseAuth;
+
+/** Utility helpers related to authentication actions. */
+public final class AuthUtils {
+
+    private AuthUtils() {
+        // Utility class
+    }
+
+    /**
+     * Signs the current Firebase user out and navigates back to the login screen.
+     * Clears the activity back stack so the user cannot return after logging out.
+     */
+    public static void signOut(@NonNull Activity activity) {
+        FirebaseAuth.getInstance().signOut();
+
+        Intent intent = new Intent(activity, LoginActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        activity.startActivity(intent);
+    }
+}

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -230,7 +230,7 @@
                 style="@style/Widget.MaterialComponents.Button.OutlinedButton"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Log out"
+                android:text="@string/logout_positive"
                 app:cornerRadius="16dp" />
 
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,10 @@
     <string name="open">Open</string>
     <string name="learn_more">Learn more</string>
 
+    <string name="logout_title">Log out</string>
+    <string name="logout_message">Are you sure you want to log out?</string>
+    <string name="logout_positive">Log out</string>
+
     <string name="greeting_guest">Hello, Guest</string>
     <string name="hero_tagline">EcoStay Retreat · Mountain escape</string>
     <string name="quick_actions">Quick actions</string>


### PR DESCRIPTION
## Summary
- prompt the user with a Material confirmation dialog before logging out from the profile tab
- centralize logout navigation logic in a new `AuthUtils` helper
- use shared string resources for the logout dialog and button label

## Testing
- ./gradlew lintVitalRelease *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1c7b023b8832192f2f5be6719fc71