### PR TITLE
Align eco info detail screen with room detail design

### DIFF
--- a/app/src/main/java/com/example/resortapp/EcoInfoDetailActivity.java
+++ b/app/src/main/java/com/example/resortapp/EcoInfoDetailActivity.java
@@ -1,12 +1,14 @@
 package com.example.resortapp;
 
 import android.os.Bundle;
+import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
 import com.bumptech.glide.Glide;
 import com.example.resortapp.model.EcoInfo;
+import com.google.android.material.appbar.MaterialToolbar;
 import com.google.firebase.firestore.*;
 
 public class EcoInfoDetailActivity extends AppCompatActivity {
@@ -14,9 +16,16 @@ public class EcoInfoDetailActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_eco_info_detail);
 
+        MaterialToolbar bar = findViewById(R.id.topAppBar);
+        if (bar != null) {
+            setSupportActionBar(bar);
+            bar.setNavigationOnClickListener(v -> onBackPressed());
+        }
+
         ImageView img = findViewById(R.id.img);
         TextView tvTitle = findViewById(R.id.tvTitle);
         TextView tvSubtitle = findViewById(R.id.tvSubtitle);
+        View subtitleDivider = findViewById(R.id.subtitleDivider);
         TextView tvDesc = findViewById(R.id.tvDesc);
 
         String id = getIntent().getStringExtra("ecoId");
@@ -27,10 +36,31 @@ public class EcoInfoDetailActivity extends AppCompatActivity {
                 .addOnSuccessListener(d -> {
                     EcoInfo e = d.toObject(EcoInfo.class);
                     if (e == null) { finish(); return; }
-                    tvTitle.setText(e.getTitle());
-                    tvSubtitle.setText(e.getSubtitle());
-                    tvDesc.setText(e.getDescription());
-                    Glide.with(this).load(e.getImageUrl()).into(img);
+                    String title = e.getTitle();
+                    if (title == null || title.trim().isEmpty()) {
+                        title = getString(R.string.app_name);
+                    }
+                    tvTitle.setText(title);
+
+                    String subtitle = e.getSubtitle();
+                    if (subtitle == null || subtitle.trim().isEmpty()) {
+                        tvSubtitle.setVisibility(View.GONE);
+                        subtitleDivider.setVisibility(View.GONE);
+                    } else {
+                        tvSubtitle.setText(subtitle);
+                        tvSubtitle.setVisibility(View.VISIBLE);
+                        subtitleDivider.setVisibility(View.VISIBLE);
+                    }
+
+                    String desc = e.getDescription();
+                    tvDesc.setText(desc != null && !desc.trim().isEmpty()
+                            ? desc
+                            : getString(R.string.eco_info_detail_no_description));
+
+                    Glide.with(this)
+                            .load(e.getImageUrl())
+                            .placeholder(R.drawable.placeholder_room)
+                            .into(img);
                 })
                 .addOnFailureListener(err -> { Toast.makeText(this, err.getMessage(), Toast.LENGTH_LONG).show(); finish(); });
     }

--- a/app/src/main/res/layout/activity_eco_info_detail.xml
+++ b/app/src/main/res/layout/activity_eco_info_detail.xml
@@ -1,33 +1,110 @@
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent" android:layout_height="match_parent">
-    <LinearLayout android:orientation="vertical" android:layout_width="match_parent" android:layout_height="wrap_content">
-        <ImageView
-            android:id="@+id/img"
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="240dp"
-            android:scaleType="centerCrop"/>
-        <LinearLayout
-            android:orientation="vertical"
-            android:padding="16dp"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <TextView
-                android:id="@+id/tvTitle"
-                android:textStyle="bold"
-                android:textSize="22sp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-            <TextView
-                android:id="@+id/tvSubtitle"
-                android:textColor="#2e7d32"
-                android:layout_marginTop="4dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
-            <TextView
-                android:id="@+id/tvDesc"
-                android:layout_marginTop="12dp"
+            android:layout_height="280dp">
+
+            <ImageView
+                android:id="@+id/img"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
+                android:layout_height="match_parent"
+                android:contentDescription="@string/app_name"
+                android:scaleType="centerCrop" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:background="@drawable/hero_scrim" />
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/topAppBar"
+                style="@style/Widget.MaterialComponents.Toolbar.Primary"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="@android:color/transparent"
+                android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
+                app:navigationIcon="@drawable/baseline_arrow_back_24"
+                app:title="" />
+        </FrameLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:paddingBottom="24dp">
+
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="-48dp"
+                android:layout_marginEnd="16dp"
+                android:clipToOutline="false"
+                app:cardCornerRadius="24dp"
+                app:cardElevation="8dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingStart="24dp"
+                    android:paddingTop="24dp"
+                    android:paddingEnd="24dp"
+                    android:paddingBottom="24dp">
+
+                    <TextView
+                        android:id="@+id/tvTitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="@android:color/black"
+                        android:textSize="24sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/tvSubtitle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondaryTextColor"
+                        android:textSize="14sp" />
+
+                    <View
+                        android:id="@+id/subtitleDivider"
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:layout_marginTop="16dp"
+                        android:background="#1F000000" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="20dp"
+                        android:text="@string/eco_info_detail_overview"
+                        android:textColor="@android:color/black"
+                        android:textSize="16sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/tvDesc"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        android:textColor="@color/secondaryTextColor"
+                        android:textSize="15sp" />
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
         </LinearLayout>
     </LinearLayout>
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,7 @@
 
     <string name="activity_detail_no_description">More information will be available soon.</string>
 
+    <string name="eco_info_detail_overview">Overview</string>
+    <string name="eco_info_detail_no_description">We&apos;ll add more eco insights soon.</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- restyle the eco info detail layout to mirror the hero image and card treatment used on the room detail screen
- add toolbar navigation handling and resilient content binding for the eco info detail activity
- introduce overview/empty-state strings used by the refreshed eco info presentation

## Testing
- ./gradlew lint *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d3ed3e348321b5fb676296355422