### PR TITLE
Add payment method selection to room booking

### DIFF
--- a/app/src/main/java/com/example/resortapp/RoomDetailActivity.java
+++ b/app/src/main/java/com/example/resortapp/RoomDetailActivity.java
@@ -5,10 +5,14 @@ import android.view.View;
 import android.widget.*;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AlertDialog;
 import com.bumptech.glide.Glide;
 import com.example.resortapp.model.Room;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.Timestamp;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.*;
@@ -65,7 +69,7 @@ public class RoomDetailActivity extends AppCompatActivity {
                 .addOnFailureListener(e -> { Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show(); finish(); });
 
         btnPickDates.setOnClickListener(v -> pickDates());
-        btnBook.setOnClickListener(v -> createBooking());
+        btnBook.setOnClickListener(v -> onBookClicked());
     }
 
     private void bindRoom() {
@@ -115,7 +119,7 @@ public class RoomDetailActivity extends AppCompatActivity {
         dp.show(getSupportFragmentManager(), "range");
     }
 
-    private void createBooking() {
+    private void onBookClicked() {
         if (room == null) return;
         if (startUtc == null || endUtc == null) {
             Toast.makeText(this, "Please select dates", Toast.LENGTH_SHORT).show(); return;
@@ -132,18 +136,109 @@ public class RoomDetailActivity extends AppCompatActivity {
         double price = room.getBasePrice() == null ? 0.0 : room.getBasePrice();
         double total = nights * price;
 
+        showPaymentDialog(uid, nights, price, total);
+    }
+
+    private void showPaymentDialog(String uid, long nights, double pricePerNight, double total) {
+        View dialogView = getLayoutInflater().inflate(R.layout.dialog_payment_method, null);
+        RadioGroup paymentGroup = dialogView.findViewById(R.id.paymentMethodGroup);
+        View cardDetailsGroup = dialogView.findViewById(R.id.cardDetailsGroup);
+        TextView tvSummary = dialogView.findViewById(R.id.tvPaymentSummary);
+        TextInputLayout tilCardName = dialogView.findViewById(R.id.tilCardName);
+        TextInputLayout tilCardNumber = dialogView.findViewById(R.id.tilCardNumber);
+        TextInputLayout tilExpiry = dialogView.findViewById(R.id.tilExpiry);
+        TextInputLayout tilCvv = dialogView.findViewById(R.id.tilCvv);
+        TextInputEditText etCardName = dialogView.findViewById(R.id.etCardName);
+        TextInputEditText etCardNumber = dialogView.findViewById(R.id.etCardNumber);
+        TextInputEditText etExpiry = dialogView.findViewById(R.id.etExpiry);
+        TextInputEditText etCvv = dialogView.findViewById(R.id.etCvv);
+
+        String summaryText = String.format(Locale.getDefault(),
+                "Stay for %d night%s\nTotal: LKR %,.0f",
+                nights,
+                nights == 1 ? "" : "s",
+                total);
+        tvSummary.setText(summaryText);
+
+        AlertDialog dialog = new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.payment_dialog_title)
+                .setView(dialogView)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(R.string.payment_dialog_positive_placeholder, null)
+                .create();
+
+        dialog.setOnShowListener(dlg -> {
+            Button btnPositive = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+            RadioGroup.OnCheckedChangeListener listener = (group, checkedId) -> {
+                boolean payingByCard = checkedId == R.id.optionPayByCard;
+                cardDetailsGroup.setVisibility(payingByCard ? View.VISIBLE : View.GONE);
+                btnPositive.setText(payingByCard
+                        ? getString(R.string.payment_dialog_positive_card)
+                        : getString(R.string.payment_dialog_positive_cash));
+            };
+
+            paymentGroup.setOnCheckedChangeListener(listener);
+
+            int checkedId = paymentGroup.getCheckedRadioButtonId();
+            if (checkedId == -1) {
+                paymentGroup.check(R.id.optionPayAtHotel);
+            } else {
+                listener.onCheckedChanged(paymentGroup, checkedId);
+            }
+
+            btnPositive.setOnClickListener(v -> {
+                int selectedId = paymentGroup.getCheckedRadioButtonId();
+                boolean payingByCard = selectedId == R.id.optionPayByCard;
+
+                tilCardName.setError(null);
+                tilCardNumber.setError(null);
+                tilExpiry.setError(null);
+                tilCvv.setError(null);
+
+                if (payingByCard) {
+                    if (etCardName.getText() == null || etCardName.getText().toString().trim().isEmpty()) {
+                        tilCardName.setError(getString(R.string.error_required));
+                        return;
+                    }
+                    if (etCardNumber.getText() == null || etCardNumber.getText().toString().trim().isEmpty()) {
+                        tilCardNumber.setError(getString(R.string.error_required));
+                        return;
+                    }
+                    if (etExpiry.getText() == null || etExpiry.getText().toString().trim().isEmpty()) {
+                        tilExpiry.setError(getString(R.string.error_required));
+                        return;
+                    }
+                    if (etCvv.getText() == null || etCvv.getText().toString().trim().isEmpty()) {
+                        tilCvv.setError(getString(R.string.error_required));
+                        return;
+                    }
+                    createBooking(uid, nights, pricePerNight, total, "CARD", "PAID");
+                } else {
+                    createBooking(uid, nights, pricePerNight, total, "PAY_AT_HOTEL", "PENDING");
+                }
+                dialog.dismiss();
+            });
+        });
+
+        dialog.show();
+    }
+
+    private void createBooking(String uid, long nights, double pricePerNight, double total,
+                               String paymentMethod, String paymentStatus) {
         Map<String, Object> b = new HashMap<>();
         b.put("kind", "ROOM");
         b.put("userId", uid);
         b.put("roomId", room.getId());
         b.put("roomName", room.getName() != null ? room.getName() : room.getType());
         b.put("roomImageUrl", room.getImageUrl());
-        b.put("priceAtBooking", price);
+        b.put("priceAtBooking", pricePerNight);
         b.put("checkIn", new Timestamp(new Date(startUtc)));
         b.put("checkOut", new Timestamp(new Date(endUtc)));
         b.put("nights", nights);
         b.put("totalAmount", total);
         b.put("status", "CONFIRMED");
+        b.put("paymentMethod", paymentMethod);
+        b.put("paymentStatus", paymentStatus);
         b.put("createdAt", FieldValue.serverTimestamp());
 
         FirebaseFirestore.getInstance().collection("bookings").add(b)

--- a/app/src/main/res/layout/dialog_payment_method.xml
+++ b/app/src/main/res/layout/dialog_payment_method.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="24dp"
+    android:paddingEnd="24dp"
+    android:paddingBottom="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/payment_dialog_summary_label"
+            android:textAllCaps="true"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Overline"
+            android:textColor="@color/secondaryTextColor" />
+
+        <TextView
+            android:id="@+id/tvPaymentSummary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+            android:textColor="@android:color/black" />
+
+        <RadioGroup
+            android:id="@+id/paymentMethodGroup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp">
+
+            <RadioButton
+                android:id="@+id/optionPayAtHotel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:text="@string/payment_dialog_pay_at_hotel" />
+
+            <RadioButton
+                android:id="@+id/optionPayByCard"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/payment_dialog_pay_with_card" />
+        </RadioGroup>
+
+        <LinearLayout
+            android:id="@+id/cardDetailsGroup"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilCardName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/payment_dialog_card_name"
+                app:endIconMode="clear_text">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etCardName"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textPersonName" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilCardNumber"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:hint="@string/payment_dialog_card_number"
+                app:endIconMode="clear_text">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etCardNumber"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="horizontal">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilExpiry"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/payment_dialog_card_expiry"
+                    app:endIconMode="clear_text">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etExpiry"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="text" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Space
+                    android:layout_width="16dp"
+                    android:layout_height="wrap_content" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilCvv"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="@string/payment_dialog_card_cvv"
+                    app:endIconMode="clear_text">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/etCvv"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="numberPassword" />
+                </com.google.android.material.textfield.TextInputLayout>
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,4 +68,17 @@
     <string name="eco_info_detail_overview">Overview</string>
     <string name="eco_info_detail_no_description">We&apos;ll add more eco insights soon.</string>
 
+    <string name="payment_dialog_title">Complete your booking</string>
+    <string name="payment_dialog_pay_at_hotel">Pay at hotel</string>
+    <string name="payment_dialog_pay_with_card">Pay with card</string>
+    <string name="payment_dialog_card_name">Name on card</string>
+    <string name="payment_dialog_card_number">Card number</string>
+    <string name="payment_dialog_card_expiry">Expiry (MM/YY)</string>
+    <string name="payment_dialog_card_cvv">CVV</string>
+    <string name="payment_dialog_positive_card">Pay now</string>
+    <string name="payment_dialog_positive_cash">Confirm booking</string>
+    <string name="payment_dialog_positive_placeholder">Confirm</string>
+    <string name="payment_dialog_summary_label">Payment summary</string>
+    <string name="error_required">Required</string>
+
 </resources>


### PR DESCRIPTION
## Summary
- add a payment method dialog to the room booking flow with pay-at-hotel and card options
- capture the selected payment method and status when saving a booking
- create supporting layout and string resources for the payment experience

## Testing
- ./gradlew lint *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ce479b388321aa56ac7a9057ebc2