### PR TITLE
Revamp activities list presentation

### DIFF
--- a/app/src/main/java/com/example/resortapp/RoomListAdapter.java
+++ b/app/src/main/java/com/example/resortapp/RoomListAdapter.java
@@ -3,7 +3,6 @@ package com.example.resortapp;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -87,9 +86,6 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
             if (onRoomClick != null) onRoomClick.onClick(r);
         };
         h.itemView.setOnClickListener(go);
-        if (h.btnView != null) {
-            h.btnView.setOnClickListener(go);
-        }
 
 
 //        h.name.setText(r.getName() != null ? r.getName() : r.getType());
@@ -108,7 +104,6 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
         ImageView img;
         TextView name, price;
         TextView desc;
-        Button btnView;
 
         VH(@NonNull View v) {
             super(v);
@@ -116,7 +111,6 @@ public class RoomListAdapter extends RecyclerView.Adapter<RoomListAdapter.VH> {
             name = v.findViewById(R.id.tvName);
             price = v.findViewById(R.id.tvPrice);
             desc = v.findViewById(R.id.tvDesc);
-            btnView = v.findViewById(R.id.btnView);
         }
     }
 

--- a/app/src/main/res/drawable/bg_activities_header.xml
+++ b/app/src/main/res/drawable/bg_activities_header.xml
@@ -1,0 +1,13 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <corners android:radius="20dp" />
+    <gradient
+        android:startColor="@color/green_primary"
+        android:endColor="@color/green_accent"
+        android:angle="45" />
+    <padding
+        android:left="0dp"
+        android:top="0dp"
+        android:right="0dp"
+        android:bottom="0dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_price_chip.xml
+++ b/app/src/main/res/drawable/bg_price_chip.xml
@@ -1,0 +1,5 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/colorPrimaryLight" />
+    <corners android:radius="50dp" />
+</shape>

--- a/app/src/main/res/layout/activity_activities_list.xml
+++ b/app/src/main/res/layout/activity_activities_list.xml
@@ -2,28 +2,54 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:background="@color/surfaceVariant">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/topAppBar"
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:background="?attr/colorSurface"
-        app:title="Activities"
+        android:elevation="0dp"
+        app:title="@string/activities_title"
+        app:titleCentered="true"
         app:navigationIcon="@drawable/abc_ic_ab_back_material" />
 
-    <TextView
-        android:id="@+id/tvTitle"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:text="Activities"
-        android:textSize="20sp"
-        android:textStyle="bold" />
+        android:layout_margin="16dp"
+        android:background="@drawable/bg_activities_header"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/activities_title"
+            android:textColor="@android:color/white"
+            android:textSize="22sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tvSubtitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/activities_subtitle"
+            android:textColor="#E8F5E9"
+            android:textSize="14sp" />
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvAllActivities"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingBottom="16dp"
+        android:paddingStart="4dp"
+        android:paddingEnd="4dp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_room_list.xml
+++ b/app/src/main/res/layout/item_room_list.xml
@@ -1,58 +1,95 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="12dp"
-    android:foreground="?attr/selectableItemBackground"
+    android:layout_marginHorizontal="16dp"
+    android:layout_marginVertical="8dp"
     android:clickable="true"
-    android:focusable="true">
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardCornerRadius="18dp"
+    app:cardElevation="4dp"
+    app:strokeColor="@color/dividerColor"
+    app:strokeWidth="1dp">
 
-    <LinearLayout
-        android:orientation="horizontal"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
         <ImageView
             android:id="@+id/img"
             android:layout_width="120dp"
-            android:layout_height="120dp"
-            android:scaleType="centerCrop"/>
+            android:layout_height="0dp"
+            android:layout_margin="16dp"
+            android:contentDescription="@null"
+            android:scaleType="centerCrop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintDimensionRatio="1:1" />
 
-        <LinearLayout
-            android:orientation="vertical"
-            android:padding="12dp"
+        <TextView
+            android:id="@+id/tvName"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1">
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:textColor="@color/dashboard_title"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/img"
+            app:layout_constraintTop_toTopOf="@id/img"
+            app:layout_goneMarginStart="12dp" />
 
-            <TextView
-                android:id="@+id/tvName"
-                android:textStyle="bold"
-                android:textSize="18sp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+        <TextView
+            android:id="@+id/tvDesc"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:maxLines="2"
+            android:textColor="@color/secondaryTextColor"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/img"
+            app:layout_constraintTop_toBottomOf="@id/tvName"
+            app:layout_goneMarginStart="12dp" />
 
-            <TextView
-                android:id="@+id/tvDesc"
-                android:ellipsize="end"
-                android:maxLines="2"
-                android:textColor="#666"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"/>
+        <TextView
+            android:id="@+id/tvPrice"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="16dp"
+            android:background="@drawable/bg_price_chip"
+            android:paddingStart="16dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="8dp"
+            android:textColor="@color/green_dark"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/img"
+            app:layout_constraintStart_toEndOf="@id/img"
+            app:layout_constraintTop_toBottomOf="@id/tvDesc"
+            app:layout_goneMarginStart="12dp" />
 
-            <TextView
-                android:id="@+id/tvPrice"
-                android:textStyle="bold"
-                android:layout_marginTop="6dp"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"/>
+        <TextView
+            android:id="@+id/tvTapHint"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:text="@string/activities_tap_hint"
+            android:textColor="@color/secondaryTextColor"
+            android:textSize="12sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/img"
+            app:layout_constraintTop_toBottomOf="@id/tvPrice"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_goneMarginStart="12dp" />
 
-            <Button
-                android:id="@+id/btnView"
-                android:text="View"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"/>
-        </LinearLayout>
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,10 @@
     <string name="adventures">Adventures</string>
     <string name="adventures_desc">Guided hikes, eco-tours</string>
 
+    <string name="activities_title">Activities &amp; Experiences</string>
+    <string name="activities_subtitle">Discover guided adventures, wellness sessions, and eco-friendly experiences tailored for your stay.</string>
+    <string name="activities_tap_hint">Tap to view details</string>
+
     <string name="bookings">My Bookings</string>
     <string name="bookings_desc">Rooms &amp; activities</string>
 


### PR DESCRIPTION
## Summary
- refresh the Activities screen with a gradient header card and softer background styling
- redesign the list item cards to highlight imagery and pricing while removing the redundant View button
- update the adapter and add supporting drawables/strings so tapping a card opens the detail view

## Testing
- ./gradlew lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e125fa188321ba1ba5889cef6bba