### PR TITLE
Await booking query results before transaction stock check

### DIFF
--- a/app/src/main/java/com/example/resortapp/FirestoreMappers.java
+++ b/app/src/main/java/com/example/resortapp/FirestoreMappers.java
@@ -9,11 +9,7 @@ public final class FirestoreMappers {
         Room r = d.toObject(Room.class);
         if (r == null) r = new Room();
         // ensure id is populated for stableIds/DiffUtil
-        try {
-            java.lang.reflect.Field f = Room.class.getDeclaredField("id");
-            f.setAccessible(true);
-            f.set(r, d.getId());
-        } catch (Exception ignored) {}
+        r.setId(d.getId());
         return r;
     }
 }

--- a/app/src/main/java/com/example/resortapp/RoomDetailActivity.java
+++ b/app/src/main/java/com/example/resortapp/RoomDetailActivity.java
@@ -6,9 +6,9 @@ import android.view.View;
 import android.widget.*;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.app.AlertDialog;
 import com.bumptech.glide.Glide;
 import com.example.resortapp.model.Room;
+import com.google.android.gms.tasks.Tasks;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.datepicker.MaterialDatePicker;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
@@ -22,6 +22,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class RoomDetailActivity extends AppCompatActivity {
@@ -32,6 +33,8 @@ public class RoomDetailActivity extends AppCompatActivity {
 
     private Room room;
     private Long startUtc = null, endUtc = null; // UTC millis
+
+    private static final int DEFAULT_ROOM_STOCK = 5;
 
     private final SimpleDateFormat fmt = new SimpleDateFormat("dd MMM yyyy", Locale.getDefault());
 
@@ -311,15 +314,92 @@ public class RoomDetailActivity extends AppCompatActivity {
                     return;
                 }
 
-                createBooking(uid, nights, pricePerNight, amountDue[0], "CARD", "PAID");
+                attemptBooking(uid, nights, pricePerNight, amountDue[0],
+                        "CARD", "PAID", btnConfirm, dialog);
             } else {
-                createBooking(uid, nights, pricePerNight, amountDue[0], "PAY_AT_HOTEL", "PENDING");
+                attemptBooking(uid, nights, pricePerNight, amountDue[0],
+                        "PAY_AT_HOTEL", "PENDING", btnConfirm, dialog);
             }
-
-            dialog.dismiss();
         });
 
         dialog.show();
+    }
+
+    private void attemptBooking(String uid,
+                                long nights,
+                                double pricePerNight,
+                                double total,
+                                String paymentMethod,
+                                String paymentStatus,
+                                MaterialButton btnConfirm,
+                                BottomSheetDialog dialog) {
+        btnConfirm.setEnabled(false);
+
+        Timestamp checkInTs = new Timestamp(new Date(startUtc));
+        Timestamp checkOutTs = new Timestamp(new Date(endUtc));
+
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        db.runTransaction(transaction -> {
+                    Query query = db.collection("bookings")
+                            .whereEqualTo("status", "CONFIRMED")
+                            .whereEqualTo("roomId", room.getId())
+                            .whereLessThan("checkIn", checkOutTs);
+
+                    QuerySnapshot prefetch;
+                    try {
+                        prefetch = Tasks.await(query.get());
+                    } catch (ExecutionException e) {
+                        throw new RuntimeException(e);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+
+                    int overlapping = 0;
+                    for (DocumentSnapshot doc : prefetch.getDocuments()) {
+                        DocumentSnapshot existing = transaction.get(doc.getReference());
+                        Timestamp existingCheckIn = existing.getTimestamp("checkIn");
+                        Timestamp existingCheckOut = existing.getTimestamp("checkOut");
+                        if (existingCheckIn == null || existingCheckOut == null) continue;
+
+                        long existingStart = existingCheckIn.toDate().getTime();
+                        long existingEnd = existingCheckOut.toDate().getTime();
+                        if (existingStart < endUtc && existingEnd > startUtc) {
+                            overlapping++;
+                        }
+                    }
+
+                    if (overlapping >= DEFAULT_ROOM_STOCK) {
+                        throw new FirebaseFirestoreException(
+                                "NO_AVAILABILITY",
+                                FirebaseFirestoreException.Code.ABORTED);
+                    }
+
+                    DocumentReference newBookingRef = db.collection("bookings").document();
+                    transaction.set(newBookingRef,
+                            buildBookingPayload(uid, nights, pricePerNight, total, paymentMethod,
+                                    paymentStatus, checkInTs, checkOutTs));
+                    return null;
+                })
+                .addOnSuccessListener(ignored -> {
+                    Toast.makeText(this, "Booked! See in My Bookings.", Toast.LENGTH_LONG).show();
+                    dialog.dismiss();
+                    finish();
+                })
+                .addOnFailureListener(e -> {
+                    btnConfirm.setEnabled(true);
+                    if (e instanceof FirebaseFirestoreException) {
+                        FirebaseFirestoreException ffe = (FirebaseFirestoreException) e;
+                        if (ffe.getCode() == FirebaseFirestoreException.Code.ABORTED &&
+                                "NO_AVAILABILITY".equals(ffe.getMessage())) {
+                            Toast.makeText(this,
+                                    R.string.room_detail_no_availability,
+                                    Toast.LENGTH_LONG).show();
+                            return;
+                        }
+                    }
+                    Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                });
     }
 
     private String getTextFromField(TextInputEditText editText) {
@@ -418,8 +498,14 @@ public class RoomDetailActivity extends AppCompatActivity {
         return digitsOnly.matches("\\d{3,4}");
     }
 
-    private void createBooking(String uid, long nights, double pricePerNight, double total,
-                               String paymentMethod, String paymentStatus) {
+    private Map<String, Object> buildBookingPayload(String uid,
+                                                    long nights,
+                                                    double pricePerNight,
+                                                    double total,
+                                                    String paymentMethod,
+                                                    String paymentStatus,
+                                                    Timestamp checkInTs,
+                                                    Timestamp checkOutTs) {
         Map<String, Object> b = new HashMap<>();
         b.put("kind", "ROOM");
         b.put("userId", uid);
@@ -427,21 +513,14 @@ public class RoomDetailActivity extends AppCompatActivity {
         b.put("roomName", room.getName() != null ? room.getName() : room.getType());
         b.put("roomImageUrl", room.getImageUrl());
         b.put("priceAtBooking", pricePerNight);
-        b.put("checkIn", new Timestamp(new Date(startUtc)));
-        b.put("checkOut", new Timestamp(new Date(endUtc)));
+        b.put("checkIn", checkInTs);
+        b.put("checkOut", checkOutTs);
         b.put("nights", nights);
         b.put("totalAmount", total);
         b.put("status", "CONFIRMED");
         b.put("paymentMethod", paymentMethod);
         b.put("paymentStatus", paymentStatus);
         b.put("createdAt", FieldValue.serverTimestamp());
-
-        FirebaseFirestore.getInstance().collection("bookings").add(b)
-                .addOnSuccessListener(ref -> {
-                    Toast.makeText(this, "Booked! See in My Bookings.", Toast.LENGTH_LONG).show();
-                    finish();
-                })
-                .addOnFailureListener(e ->
-                        Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show());
+        return b;
     }
 }

--- a/app/src/main/java/com/example/resortapp/model/Room.java
+++ b/app/src/main/java/com/example/resortapp/model/Room.java
@@ -9,6 +9,8 @@ public class Room {
     private String imageUrl;
     private String status;
     private Integer capacity;
+    private transient Integer availableRooms;
+    private transient boolean soldOut;
 
     public Room() {}
 
@@ -20,5 +22,35 @@ public class Room {
     public String getImageUrl() { return imageUrl; }
     public String getStatus() { return status; }
     public Integer getCapacity() { return capacity; }
+
+    public void setId(String id) { this.id = id; }
+    public void setName(String name) { this.name = name; }
+    public void setType(String type) { this.type = type; }
+    public void setDescription(String description) { this.description = description; }
+    public void setBasePrice(Double basePrice) { this.basePrice = basePrice; }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+    public void setStatus(String status) { this.status = status; }
+    public void setCapacity(Integer capacity) { this.capacity = capacity; }
+
+    public Integer getAvailableRooms() { return availableRooms; }
+    public void setAvailableRooms(Integer availableRooms) { this.availableRooms = availableRooms; }
+
+    public boolean isSoldOut() { return soldOut; }
+    public void setSoldOut(boolean soldOut) { this.soldOut = soldOut; }
+
+    public Room copy() {
+        Room r = new Room();
+        r.id = this.id;
+        r.name = this.name;
+        r.type = this.type;
+        r.description = this.description;
+        r.basePrice = this.basePrice;
+        r.imageUrl = this.imageUrl;
+        r.status = this.status;
+        r.capacity = this.capacity;
+        r.availableRooms = this.availableRooms;
+        r.soldOut = this.soldOut;
+        return r;
+    }
 }
 

--- a/app/src/main/java/com/example/resortapp/util/Helper.java
+++ b/app/src/main/java/com/example/resortapp/util/Helper.java
@@ -22,46 +22,46 @@ public class Helper {
         CollectionReference rooms = db.collection("rooms");
 
         // ECO PODS
-        addRoom(batch, rooms, room("Eco Pod A", "Eco-Pod",
-                "Compact pod built with recycled materials; skylight & solar power.",
-                12000, 2, "eco_pod",
-                "https://images.unsplash.com/photo-1505691723518-36a5ac3b2d53"));
-        addRoom(batch, rooms, room("Eco Pod B", "Eco-Pod",
-                "Minimalist pod near herb garden; great stargazing.",
-                12500, 2, "eco_pod",
-                "https://images.unsplash.com/photo-1519710164239-da123dc03ef4"));
-        addRoom(batch, rooms, room("Eco Pod C", "Eco-Pod",
-                "Cozy pod with bamboo interior, low‑energy AC.",
-                11800, 2, "eco_pod",
-                "https://images.unsplash.com/photo-1501183638710-841dd1904471"));
+        addRoom(batch, rooms, room("Eco Pod Queen Retreat", "Queen Bedroom",
+                "Compact pod with queen bed, skylight, and solar-cooled airflow.",
+                18500, 2, "eco_pod",
+                "https://images.unsplash.com/photo-1542314831-068cd1dbfeeb"));
+        addRoom(batch, rooms, room("Eco Pod King Escape", "King Bedroom",
+                "Spacious pod featuring king bed, bamboo finishes, and private deck.",
+                21500, 2, "eco_pod",
+                "https://images.unsplash.com/photo-1568605114967-8130f3a36994"));
+        addRoom(batch, rooms, room("Eco Pod Family Haven", "Family Bedroom",
+                "Interconnected pods with a queen, twin bunks, and reading nook.",
+                25500, 4, "eco_pod",
+                "https://images.unsplash.com/photo-1559599788-86c2f8d04d98"));
 
         // MOUNTAIN CABINS
-        addRoom(batch, rooms, room("Mountain Cabin 1", "Cabin",
-                "Rustic cabin with fireplace and panoramic mountain view.",
-                26000, 3, "mountain_cabin",
-                "https://images.unsplash.com/photo-1522708323590-d24dbb6b0267"));
-        addRoom(batch, rooms, room("Mountain Cabin 2", "Cabin",
-                "Two‑bedroom timber cabin; balcony & hammock.",
-                28500, 4, "mountain_cabin",
+        addRoom(batch, rooms, room("Mountain Cabin Queen Lookout", "Queen Bedroom",
+                "Warm timber cabin with queen bed, fireplace, and terrace view.",
+                26500, 2, "mountain_cabin",
+                "https://images.unsplash.com/photo-1441974231531-c6227db76b6e"));
+        addRoom(batch, rooms, room("Mountain Cabin King Summit", "King Bedroom",
+                "King suite boasting vaulted ceilings, soaking tub, and ridge balcony.",
+                31500, 3, "mountain_cabin",
+                "https://images.unsplash.com/photo-1439130490301-25e322d88054"));
+        addRoom(batch, rooms, room("Mountain Cabin Family Lodge", "Family Bedroom",
+                "Two-bedroom family lodge with loft bunks and kitchenette.",
+                36500, 5, "mountain_cabin",
                 "https://images.unsplash.com/photo-1505691938895-1758d7feb511"));
-        addRoom(batch, rooms, room("Deluxe Mountain Suite", "Cabin",
-                "Spacious suite, kitchenette, ridge‑line view.",
-                32000, 5, "mountain_cabin",
-                "https://images.unsplash.com/photo-1496412705862-e0088f16f791"));
 
         // RIVER HUTS
-        addRoom(batch, rooms, room("River Hut A", "Hut",
-                "Thatched hut by the river; mosquito nets; solar lamps.",
-                18000, 2, "river_hut",
-                "https://images.unsplash.com/photo-1505692794403-34d4982f88aa"));
-        addRoom(batch, rooms, room("River Hut B", "Hut",
-                "Open‑air veranda, reed walls, gentle river breeze.",
-                19500, 3, "river_hut",
+        addRoom(batch, rooms, room("River Hut Queen Breeze", "Queen Bedroom",
+                "Riverside hut with queen canopy bed and open-air lounge.",
+                20500, 2, "river_hut",
+                "https://images.unsplash.com/photo-1505691723518-36a5ac3b2d53"));
+        addRoom(batch, rooms, room("River Hut King Drift", "King Bedroom",
+                "Waterfront hut featuring king bed, daybed, and bamboo shower.",
+                23500, 2, "river_hut",
+                "https://images.unsplash.com/photo-1470246973918-29a93221c455"));
+        addRoom(batch, rooms, room("River Hut Family Cove", "Family Bedroom",
+                "Dual-room family hut with queen master, twin bunks, and hammocks.",
+                27500, 4, "river_hut",
                 "https://images.unsplash.com/photo-1484154218962-a197022b5858"));
-        addRoom(batch, rooms, room("Family River Hut", "Hut",
-                "Family‑sized hut with two rooms and eco‑fans.",
-                21000, 4, "river_hut",
-                "https://images.unsplash.com/photo-1499696010180-025ef6e1a8f6"));
 
         batch.commit()
                 .addOnSuccessListener(unused -> {

--- a/app/src/main/res/layout/activity_rooms_list.xml
+++ b/app/src/main/res/layout/activity_rooms_list.xml
@@ -23,6 +23,73 @@
         android:textSize="20sp"
         android:textStyle="bold" />
 
+    <com.google.android.material.card.MaterialCardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        app:cardCornerRadius="16dp"
+        app:cardElevation="2dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/tvFiltersTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/rooms_filters_title"
+                android:textColor="@color/dashboard_title"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/rooms_filter_room_type_label"
+                    android:textColor="@color/secondaryTextColor"
+                    android:textSize="13sp" />
+
+                <Spinner
+                    android:id="@+id/spRoomTypeFilter"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp" />
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/rooms_filter_price_label"
+                    android:textColor="@color/secondaryTextColor"
+                    android:textSize="13sp" />
+
+                <Spinner
+                    android:id="@+id/spPriceFilter"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvAllRooms"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_room_card.xml
+++ b/app/src/main/res/layout/item_room_card.xml
@@ -56,6 +56,23 @@
                 android:textColor="@android:color/black"
                 android:textSize="14sp"
                 android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvAvailability"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:textColor="@color/green_dark"
+                android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/tvTapHint"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/rooms_tap_hint"
+                android:textColor="@color/secondaryTextColor"
+                android:textSize="12sp" />
         </LinearLayout>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_room_list.xml
+++ b/app/src/main/res/layout/item_room_list.xml
@@ -80,18 +80,31 @@
             app:layout_goneMarginStart="12dp" />
 
         <TextView
+            android:id="@+id/tvAvailability"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="8dp"
+            android:textColor="@color/green_dark"
+            android:textSize="13sp"
+            app:layout_constraintStart_toEndOf="@id/img"
+            app:layout_constraintTop_toBottomOf="@id/tvPrice"
+            app:layout_constraintBottom_toTopOf="@id/tvTapHint"
+            app:layout_goneMarginStart="12dp" />
+
+        <TextView
             android:id="@+id/tvTapHint"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="12dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="16dp"
-            android:text="@string/activities_tap_hint"
+            android:text="@string/rooms_tap_hint"
             android:textColor="@color/secondaryTextColor"
             android:textSize="12sp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/img"
-            app:layout_constraintTop_toBottomOf="@id/tvPrice"
+            app:layout_constraintTop_toBottomOf="@id/tvAvailability"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_goneMarginStart="12dp" />
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -23,4 +23,18 @@
         <item>single</item>
         <item>party</item>
     </string-array>
+
+    <string-array name="rooms_filter_type_options">
+        <item>@string/rooms_filter_type_all</item>
+        <item>@string/rooms_filter_type_queen</item>
+        <item>@string/rooms_filter_type_king</item>
+        <item>@string/rooms_filter_type_family</item>
+    </string-array>
+
+    <string-array name="rooms_filter_price_options">
+        <item>@string/rooms_filter_price_any</item>
+        <item>@string/rooms_filter_price_below_20000</item>
+        <item>@string/rooms_filter_price_between_20000_40000</item>
+        <item>@string/rooms_filter_price_above_40000</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -18,4 +18,5 @@
     <color name="surfaceVariant">#FFF5F7F9</color>
     <color name="colorPrimaryLight">#E8F5E9</color>
     <color name="dividerColor">#FFE0E0E0</color>
+    <color name="rooms_sold_out">#C62828</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,26 @@
     <string name="activities_subtitle">Discover guided adventures, wellness sessions, and eco-friendly experiences tailored for your stay.</string>
     <string name="activities_tap_hint">Tap to view details</string>
 
+    <string name="rooms_filters_title">Filter rooms</string>
+    <string name="rooms_filter_room_type_label">Room type</string>
+    <string name="rooms_filter_price_label">Price</string>
+    <string name="rooms_filter_type_all">All room types</string>
+    <string name="rooms_filter_type_queen">Queens bedroom</string>
+    <string name="rooms_filter_type_king">Kings bedroom</string>
+    <string name="rooms_filter_type_family">Family bedroom</string>
+    <string name="rooms_filter_price_any">Any price</string>
+    <string name="rooms_filter_price_below_20000">Below LKR 20,000</string>
+    <string name="rooms_filter_price_between_20000_40000">LKR 20,000 - 40,000</string>
+    <string name="rooms_filter_price_above_40000">Above LKR 40,000</string>
+    <string name="rooms_tap_hint">Tap to view details</string>
+    <string name="rooms_sold_out_label">You missed it</string>
+    <string name="room_detail_no_availability">This room is fully booked for the selected dates.</string>
+
+    <plurals name="rooms_availability_count">
+        <item quantity="one">%d room available</item>
+        <item quantity="other">%d rooms available</item>
+    </plurals>
+
     <string name="bookings">My Bookings</string>
     <string name="bookings_desc">Rooms &amp; activities</string>
 


### PR DESCRIPTION
## Summary
- await the confirmed bookings query before locking and counting overlapping reservations inside the transaction to enforce the five-room cap
- add the required task and exception imports for the awaited query flow

## Testing
- ./gradlew lint *(fails: Android SDK not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e53350355883218f6f561acd787c9e