### PR TITLE
Show loader while checking activity availability

### DIFF
--- a/app/src/main/java/com/example/resortapp/ActivityDetailActivity.java
+++ b/app/src/main/java/com/example/resortapp/ActivityDetailActivity.java
@@ -6,22 +6,31 @@ import android.widget.*;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import com.bumptech.glide.Glide;
+import com.google.android.gms.tasks.Tasks;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
 import com.google.firebase.Timestamp;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 public class ActivityDetailActivity extends AppCompatActivity {
 
     private ImageView img; private TextView tvName, tvPrice, tvMeta, tvDesc, tvDate;
     private Button btnPickDate, btnReserve; private EditText etParticipants;
+    private CircularProgressIndicator progressReserve;
 
     private DocumentSnapshot activityDoc;
     private Long dateUtc = null; // activity day
+    private long capacityPerSession = DEFAULT_ACTIVITY_CAPACITY;
+    private boolean reserveInProgress = false;
     private final SimpleDateFormat fmt = new SimpleDateFormat("dd MMM yyyy", Locale.getDefault());
+
+    private static final int DEFAULT_ACTIVITY_CAPACITY = 10;
 
     @Override protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -42,6 +51,7 @@ public class ActivityDetailActivity extends AppCompatActivity {
         btnPickDate = findViewById(R.id.btnPickDate);
         btnReserve = findViewById(R.id.btnReserve);
         etParticipants = findViewById(R.id.etParticipants);
+        progressReserve = findViewById(R.id.progressReserve);
 
         String id = getIntent().getStringExtra("activityId");
         if (id == null) { finish(); return; }
@@ -61,6 +71,15 @@ public class ActivityDetailActivity extends AppCompatActivity {
                     tvDesc.setText(desc != null && !desc.trim().isEmpty()
                             ? desc
                             : getString(R.string.activity_detail_no_description));
+                    if (tvMeta != null) {
+                        if (capacity != null && capacity > 0) {
+                            capacityPerSession = capacity;
+                            tvMeta.setVisibility(View.VISIBLE);
+                            tvMeta.setText(getString(R.string.activity_detail_meta_capacity_format, capacity));
+                        } else {
+                            tvMeta.setVisibility(View.GONE);
+                        }
+                    }
                     Glide.with(this).load(imageUrl).placeholder(R.drawable.placeholder_room).into(img);
                 })
                 .addOnFailureListener(e -> { Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show(); finish(); });
@@ -79,6 +98,7 @@ public class ActivityDetailActivity extends AppCompatActivity {
 
     private void reserve() {
         if (activityDoc == null) return;
+        if (reserveInProgress) return;
         if (dateUtc == null) { Toast.makeText(this, "Select a date", Toast.LENGTH_SHORT).show(); return; }
 
         String uid = FirebaseAuth.getInstance().getUid();
@@ -91,24 +111,104 @@ public class ActivityDetailActivity extends AppCompatActivity {
         double price = activityDoc.getDouble("pricePerPerson") == null ? 0.0 : activityDoc.getDouble("pricePerPerson");
         double total = price * participants;
 
-        Map<String,Object> b = new HashMap<>();
+        Timestamp dayStart = new Timestamp(new Date(dateUtc));
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(dateUtc);
+        cal.add(Calendar.DAY_OF_YEAR, 1);
+        Timestamp nextDay = new Timestamp(cal.getTime());
+
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        setReserveInProgress(true);
+
+        db.runTransaction(transaction -> {
+                    Query query = db.collection("bookings")
+                            .whereEqualTo("status", "CONFIRMED")
+                            .whereEqualTo("kind", "ACTIVITY")
+                            .whereEqualTo("activityId", activityDoc.getId())
+                            .whereGreaterThanOrEqualTo("scheduleStart", dayStart)
+                            .whereLessThan("scheduleStart", nextDay);
+
+                    QuerySnapshot prefetch;
+                    try {
+                        prefetch = Tasks.await(query.get());
+                    } catch (ExecutionException e) {
+                        throw new RuntimeException(e);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+
+                    int reserved = 0;
+                    for (DocumentSnapshot doc : prefetch.getDocuments()) {
+                        DocumentSnapshot existing = transaction.get(doc.getReference());
+                        Long existingParticipants = existing.getLong("participants");
+                        if (existingParticipants != null) {
+                            reserved += existingParticipants.intValue();
+                        }
+                    }
+
+                    if (reserved + participants > capacityPerSession) {
+                        throw new FirebaseFirestoreException(
+                                "NO_AVAILABILITY",
+                                FirebaseFirestoreException.Code.ABORTED);
+                    }
+
+                    DocumentReference newBookingRef = db.collection("bookings").document();
+                    transaction.set(newBookingRef, buildActivityBookingPayload(uid, participants, price, total, dayStart));
+                    return null;
+                })
+                .addOnSuccessListener(ignored -> {
+                    setReserveInProgress(false);
+                    Toast.makeText(this, "Reserved! See in My Bookings.", Toast.LENGTH_LONG).show();
+                    finish();
+                })
+                .addOnFailureListener(e -> {
+                    setReserveInProgress(false);
+                    if (e instanceof FirebaseFirestoreException) {
+                        FirebaseFirestoreException ffe = (FirebaseFirestoreException) e;
+                        if (ffe.getCode() == FirebaseFirestoreException.Code.ABORTED &&
+                                "NO_AVAILABILITY".equals(ffe.getMessage())) {
+                            showNoAvailabilityDialog();
+                            return;
+                        }
+                    }
+                    Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show();
+                });
+    }
+
+    private void setReserveInProgress(boolean inProgress) {
+        reserveInProgress = inProgress;
+        btnReserve.setEnabled(!inProgress);
+        if (progressReserve != null) {
+            progressReserve.setVisibility(inProgress ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private Map<String, Object> buildActivityBookingPayload(String uid,
+                                                            int participants,
+                                                            double pricePerPerson,
+                                                            double total,
+                                                            Timestamp scheduleStart) {
+        Map<String, Object> b = new HashMap<>();
         b.put("kind", "ACTIVITY");
         b.put("userId", uid);
         b.put("activityId", activityDoc.getId());
         b.put("activityName", activityDoc.getString("name"));
         b.put("activityImageUrl", activityDoc.getString("imageUrl"));
-        b.put("priceAtBooking", price);
+        b.put("priceAtBooking", pricePerPerson);
         b.put("participants", participants);
-        b.put("scheduleStart", new Timestamp(new Date(dateUtc)));
+        b.put("scheduleStart", scheduleStart);
         b.put("totalAmount", total);
         b.put("status", "CONFIRMED");
         b.put("createdAt", FieldValue.serverTimestamp());
+        return b;
+    }
 
-        FirebaseFirestore.getInstance().collection("bookings").add(b)
-                .addOnSuccessListener(ref -> {
-                    Toast.makeText(this, "Reserved! See in My Bookings.", Toast.LENGTH_LONG).show();
-                    finish();
-                })
-                .addOnFailureListener(e -> Toast.makeText(this, e.getMessage(), Toast.LENGTH_LONG).show());
+    private void showNoAvailabilityDialog() {
+        new MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.activity_detail_no_availability_dialog_title)
+                .setMessage(R.string.activity_detail_no_availability_dialog_message)
+                .setPositiveButton(android.R.string.ok, null)
+                .show();
     }
 }

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -73,6 +73,15 @@
                         android:textStyle="bold" />
 
                     <TextView
+                        android:id="@+id/tvMeta"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:textColor="@color/secondaryTextColor"
+                        android:textSize="14sp"
+                        android:visibility="gone" />
+
+                    <TextView
                         android:id="@+id/tvPrice"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
@@ -185,6 +194,17 @@
                         android:layout_marginTop="24dp"
                         android:text="Reserve activity"
                         app:cornerRadius="12dp" />
+
+                    <com.google.android.material.progressindicator.CircularProgressIndicator
+                        android:id="@+id/progressReserve"
+                        style="@style/Widget.MaterialComponents.CircularProgressIndicator"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginTop="16dp"
+                        android:visibility="gone"
+                        app:indicatorSize="48dp"
+                        app:trackThickness="4dp" />
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
         </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,9 @@
     <string name="room_detail_no_description">Details coming soon.</string>
 
     <string name="activity_detail_no_description">More information will be available soon.</string>
+    <string name="activity_detail_meta_capacity_format">Up to %1$d guests per session</string>
+    <string name="activity_detail_no_availability_dialog_title">Fully booked</string>
+    <string name="activity_detail_no_availability_dialog_message">This activity is fully booked for your selected date. Please select a different day.</string>
 
     <string name="eco_info_detail_overview">Overview</string>
     <string name="eco_info_detail_no_description">We&apos;ll add more eco insights soon.</string>


### PR DESCRIPTION
## Summary
- add the missing metadata text view to the activity detail screen layout
- guard capacity UI updates in the activity detail controller to prevent null pointer crashes
- show a circular loader while validating activity availability before confirming the reservation

## Testing
- not run (Android SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e5480153f08321a16c0602930b4e39