### PR TITLE
Add activity reservation management actions

### DIFF
--- a/app/src/main/java/com/example/resortapp/BookingsFragment.java
+++ b/app/src/main/java/com/example/resortapp/BookingsFragment.java
@@ -1,81 +1,114 @@
 package com.example.resortapp;
 
-
 import android.os.Bundle;
-import android.view.*;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
 
-import androidx.annotation.*;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
-
+import com.google.android.gms.tasks.Tasks;
+import com.google.android.material.button.MaterialButton;
 import com.google.android.material.chip.ChipGroup;
+import com.google.android.material.datepicker.MaterialDatePicker;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.progressindicator.CircularProgressIndicator;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import com.google.firebase.Timestamp;
 import com.google.firebase.auth.FirebaseAuth;
-import com.google.firebase.firestore.*;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.ListenerRegistration;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
 
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class BookingsFragment extends Fragment {
+
+    private static final int DEFAULT_ACTIVITY_CAPACITY = 10;
+
+    private final SimpleDateFormat activityDateFormat = new SimpleDateFormat("dd MMM yyyy", Locale.getDefault());
 
     private RecyclerView rv;
     private BookingAdapter adapter;
     private ListenerRegistration reg;
-    // fields
     private String currentKind = "ROOM"; // default
 
-    @Nullable @Override
-    public View onCreateView(@NonNull LayoutInflater i, @Nullable ViewGroup c, @Nullable Bundle b) {
-        View v = i.inflate(R.layout.fragment_bookings, c, false);
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        View v = inflater.inflate(R.layout.fragment_bookings, container, false);
         rv = v.findViewById(R.id.rvBookings);
         rv.setLayoutManager(new LinearLayoutManager(getContext()));
-        adapter = new BookingAdapter();
+        adapter = new BookingAdapter(new BookingAdapter.OnBookingActionListener() {
+            @Override
+            public void onEditActivity(@NonNull BookingItem item) {
+                showUpdateActivityDialog(item);
+            }
+
+            @Override
+            public void onDeleteActivity(@NonNull BookingItem item) {
+                confirmDeleteActivity(item);
+            }
+        });
         rv.setAdapter(adapter);
 
-        String uid = FirebaseAuth.getInstance().getUid();
-        Query q = FirebaseFirestore.getInstance().collection("bookings")
-                .whereEqualTo("userId", uid)
-                .orderBy("createdAt", Query.Direction.DESCENDING);
-
-        reg = q.addSnapshotListener((qs, e) -> {
-            if (e != null || qs == null) return;
-            List<BookingItem> items = new ArrayList<>();
-            for (DocumentSnapshot d : qs.getDocuments()) {
-                items.add(BookingItem.from(d));
-            }
-            adapter.submit(items);
-        });
-
-        // in onCreateView after setting adapter & rv:
         ChipGroup chips = v.findViewById(R.id.chipGroup);
         chips.setOnCheckedStateChangeListener((group, checkedIds) -> {
-            if (checkedIds == null || checkedIds.isEmpty()) return;
+            if (checkedIds == null || checkedIds.isEmpty()) {
+                return;
+            }
             int id = checkedIds.get(0);
             currentKind = (id == R.id.chipActivities) ? "ACTIVITY" : "ROOM";
             subscribe();
         });
 
-// initial:
         subscribe();
 
         return v;
     }
 
     private void subscribe() {
-        if (reg != null) { reg.remove(); reg = null; }
+        if (reg != null) {
+            reg.remove();
+            reg = null;
+        }
         String uid = FirebaseAuth.getInstance().getUid();
+        if (uid == null) {
+            adapter.submit(new ArrayList<>());
+            return;
+        }
         Query q = FirebaseFirestore.getInstance().collection("bookings")
                 .whereEqualTo("userId", uid)
                 .whereEqualTo("kind", currentKind)
                 .orderBy("createdAt", Query.Direction.DESCENDING);
 
         reg = q.addSnapshotListener((qs, e) -> {
-            if (e != null || qs == null) return;
+            if (e != null || qs == null) {
+                return;
+            }
             List<BookingItem> items = new ArrayList<>();
             for (DocumentSnapshot d : qs.getDocuments()) {
                 items.add(BookingItem.from(d));
@@ -84,47 +117,318 @@ public class BookingsFragment extends Fragment {
         });
     }
 
-    @Override public void onDestroyView() {
+    @Override
+    public void onDestroyView() {
         super.onDestroyView();
-        if (rv != null) rv.setAdapter(null);
+        if (rv != null) {
+            rv.setAdapter(null);
+        }
         adapter = null;
-        if (reg != null) { reg.remove(); reg = null; }
+        if (reg != null) {
+            reg.remove();
+            reg = null;
+        }
     }
 
-    // ---- Data + adapter
-    static class BookingItem {
-        String id, roomName, roomImageUrl, status;
-        Date checkIn, checkOut;
-        Double totalAmount;
+    private void showUpdateActivityDialog(@NonNull BookingItem item) {
+        if (!"ACTIVITY".equals(item.kind) || !isAdded()) {
+            return;
+        }
 
-//        static BookingItem from(DocumentSnapshot d) {
-//            BookingItem i = new BookingItem();
-//            i.id = d.getId();
-//            i.roomName = d.getString("roomName");
-//            i.roomImageUrl = d.getString("roomImageUrl");
-//            i.status = d.getString("status");
-//            Timestamp ci = d.getTimestamp("checkIn");
-//            Timestamp co = d.getTimestamp("checkOut");
-//            i.checkIn = ci != null ? ci.toDate() : null;
-//            i.checkOut = co != null ? co.toDate() : null;
-//            i.totalAmount = d.getDouble("totalAmount");
-//            return i;
-//        }
+        View dialogView = LayoutInflater.from(requireContext()).inflate(R.layout.dialog_update_activity_booking, null, false);
+        TextView tvTitle = dialogView.findViewById(R.id.tvDialogTitle);
+        TextView tvSelectedDate = dialogView.findViewById(R.id.tvSelectedDate);
+        MaterialButton btnPickDate = dialogView.findViewById(R.id.btnPickDate);
+        TextInputLayout tilParticipants = dialogView.findViewById(R.id.tilParticipants);
+        TextInputEditText etParticipants = dialogView.findViewById(R.id.etParticipants);
+        CircularProgressIndicator progress = dialogView.findViewById(R.id.progressUpdate);
+
+        tvTitle.setText(!TextUtils.isEmpty(item.roomName) ? item.roomName : getString(R.string.inbox_activity_default_title));
+
+        final long[] selectedDateUtc = new long[1];
+        if (item.checkIn != null) {
+            selectedDateUtc[0] = item.checkIn.getTime();
+        } else {
+            selectedDateUtc[0] = MaterialDatePicker.todayInUtcMilliseconds();
+        }
+        tvSelectedDate.setText(activityDateFormat.format(new Date(selectedDateUtc[0])));
+
+        btnPickDate.setOnClickListener(v -> {
+            MaterialDatePicker.Builder<Long> builder = MaterialDatePicker.Builder.datePicker();
+            builder.setTitleText(R.string.booking_activity_update_pick_date);
+            builder.setSelection(selectedDateUtc[0]);
+            MaterialDatePicker<Long> picker = builder.build();
+            picker.addOnPositiveButtonClickListener(selection -> {
+                if (selection == null) {
+                    return;
+                }
+                selectedDateUtc[0] = selection;
+                tvSelectedDate.setText(activityDateFormat.format(new Date(selection)));
+            });
+            picker.show(getChildFragmentManager(), "activity_update_date");
+        });
+
+        if (item.participants > 0) {
+            etParticipants.setText(String.valueOf(item.participants));
+        }
+
+        MaterialAlertDialogBuilder builder = new MaterialAlertDialogBuilder(requireContext())
+                .setView(dialogView)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(R.string.booking_activity_update_positive, null);
+
+        android.app.AlertDialog dialog = builder.create();
+        dialog.setOnShowListener(d -> {
+            Button positiveButton = dialog.getButton(android.app.AlertDialog.BUTTON_POSITIVE);
+            positiveButton.setOnClickListener(v -> {
+                tilParticipants.setError(null);
+                String participantsText = etParticipants.getText() != null ? etParticipants.getText().toString().trim() : "";
+                if (TextUtils.isEmpty(participantsText)) {
+                    tilParticipants.setError(getString(R.string.booking_activity_update_validation_participants));
+                    return;
+                }
+                int participants;
+                try {
+                    participants = Integer.parseInt(participantsText);
+                } catch (NumberFormatException ex) {
+                    tilParticipants.setError(getString(R.string.booking_activity_update_validation_participants));
+                    return;
+                }
+                if (participants <= 0) {
+                    tilParticipants.setError(getString(R.string.booking_activity_update_validation_participants));
+                    return;
+                }
+                if (selectedDateUtc[0] <= 0) {
+                    Toast.makeText(requireContext(), R.string.booking_activity_update_validation_date, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+                setUpdateDialogInProgress(true, progress, positiveButton, btnPickDate, etParticipants);
+                updateActivityReservation(item, selectedDateUtc[0], participants, new ActivityUpdateCallback() {
+                    @Override
+                    public void onSuccess() {
+                        if (!isAdded()) {
+                            return;
+                        }
+                        Toast.makeText(requireContext(), R.string.booking_activity_update_success, Toast.LENGTH_SHORT).show();
+                        dialog.dismiss();
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        if (!isAdded()) {
+                            return;
+                        }
+                        setUpdateDialogInProgress(false, progress, positiveButton, btnPickDate, etParticipants);
+                        if (e instanceof FirebaseFirestoreException) {
+                            FirebaseFirestoreException ffe = (FirebaseFirestoreException) e;
+                            if (ffe.getCode() == FirebaseFirestoreException.Code.ABORTED && "NO_AVAILABILITY".equals(ffe.getMessage())) {
+                                showNoAvailabilityDialog();
+                                return;
+                            }
+                        }
+                        Toast.makeText(requireContext(), e.getMessage(), Toast.LENGTH_LONG).show();
+                    }
+                });
+            });
+        });
+        dialog.show();
+    }
+
+    private void setUpdateDialogInProgress(boolean inProgress,
+                                            CircularProgressIndicator progress,
+                                            Button positiveButton,
+                                            MaterialButton btnPickDate,
+                                            TextInputEditText etParticipants) {
+        progress.setVisibility(inProgress ? View.VISIBLE : View.GONE);
+        positiveButton.setEnabled(!inProgress);
+        btnPickDate.setEnabled(!inProgress);
+        etParticipants.setEnabled(!inProgress);
+    }
+
+    private void updateActivityReservation(@NonNull BookingItem item,
+                                           long dateUtc,
+                                           int participants,
+                                           @NonNull ActivityUpdateCallback callback) {
+        FirebaseFirestore db = FirebaseFirestore.getInstance();
+        Timestamp dayStart = new Timestamp(new Date(dateUtc));
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeInMillis(dateUtc);
+        cal.add(Calendar.DAY_OF_YEAR, 1);
+        Timestamp nextDay = new Timestamp(cal.getTime());
+
+        db.runTransaction(transaction -> {
+            DocumentReference bookingRef = db.collection("bookings").document(item.id);
+            DocumentSnapshot bookingSnapshot = transaction.get(bookingRef);
+            if (!bookingSnapshot.exists()) {
+                throw new FirebaseFirestoreException("NOT_FOUND", FirebaseFirestoreException.Code.NOT_FOUND);
+            }
+
+            String activityId = bookingSnapshot.getString("activityId");
+            if (activityId == null) {
+                activityId = item.activityId;
+            }
+            if (activityId == null) {
+                throw new FirebaseFirestoreException("INVALID_ACTIVITY", FirebaseFirestoreException.Code.ABORTED);
+            }
+
+            DocumentReference activityRef = db.collection("activities").document(activityId);
+            DocumentSnapshot activitySnapshot = transaction.get(activityRef);
+
+            long capacity = DEFAULT_ACTIVITY_CAPACITY;
+            if (activitySnapshot.exists()) {
+                Long cap = activitySnapshot.getLong("capacityPerSession");
+                if (cap != null && cap > 0) {
+                    capacity = cap;
+                }
+            }
+
+            Query query = db.collection("bookings")
+                    .whereEqualTo("status", "CONFIRMED")
+                    .whereEqualTo("kind", "ACTIVITY")
+                    .whereEqualTo("activityId", activityId)
+                    .whereGreaterThanOrEqualTo("scheduleStart", dayStart)
+                    .whereLessThan("scheduleStart", nextDay);
+
+            QuerySnapshot existing;
+            try {
+                existing = Tasks.await(query.get());
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+
+            int reserved = 0;
+            for (DocumentSnapshot doc : existing.getDocuments()) {
+                if (doc.getId().equals(item.id)) {
+                    continue;
+                }
+                Long existingParticipants = doc.getLong("participants");
+                if (existingParticipants != null) {
+                    reserved += existingParticipants.intValue();
+                }
+            }
+
+            if (reserved + participants > capacity) {
+                throw new FirebaseFirestoreException("NO_AVAILABILITY", FirebaseFirestoreException.Code.ABORTED);
+            }
+
+            double price = 0.0;
+            Double priceAtBooking = bookingSnapshot.getDouble("priceAtBooking");
+            if (priceAtBooking != null) {
+                price = priceAtBooking;
+            } else if (activitySnapshot.exists()) {
+                Double pricePerPerson = activitySnapshot.getDouble("pricePerPerson");
+                if (pricePerPerson != null) {
+                    price = pricePerPerson;
+                }
+            } else if (item.pricePerPerson != null) {
+                price = item.pricePerPerson;
+            }
+
+            Map<String, Object> updates = new HashMap<>();
+            updates.put("participants", participants);
+            updates.put("scheduleStart", dayStart);
+            updates.put("totalAmount", price * participants);
+            updates.put("priceAtBooking", price);
+            transaction.update(bookingRef, updates);
+            return null;
+        }).addOnSuccessListener(unused -> callback.onSuccess())
+                .addOnFailureListener(e -> {
+                    if (e instanceof RuntimeException && e.getCause() instanceof Exception) {
+                        callback.onFailure((Exception) e.getCause());
+                    } else {
+                        callback.onFailure(e);
+                    }
+                });
+    }
+
+    private void confirmDeleteActivity(@NonNull BookingItem item) {
+        if (!isAdded()) {
+            return;
+        }
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.booking_activity_delete_confirm_title)
+                .setMessage(R.string.booking_activity_delete_confirm_message)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(R.string.booking_action_delete, (dialog, which) -> deleteActivityBooking(item))
+                .show();
+    }
+
+    private void deleteActivityBooking(@NonNull BookingItem item) {
+        FirebaseFirestore.getInstance().collection("bookings")
+                .document(item.id)
+                .delete()
+                .addOnSuccessListener(unused -> {
+                    if (!isAdded()) {
+                        return;
+                    }
+                    Toast.makeText(requireContext(), R.string.booking_activity_delete_success, Toast.LENGTH_SHORT).show();
+                })
+                .addOnFailureListener(e -> {
+                    if (!isAdded()) {
+                        return;
+                    }
+                    Toast.makeText(requireContext(), e.getMessage(), Toast.LENGTH_LONG).show();
+                });
+    }
+
+    private void showNoAvailabilityDialog() {
+        if (!isAdded()) {
+            return;
+        }
+        new MaterialAlertDialogBuilder(requireContext())
+                .setTitle(R.string.activity_detail_no_availability_dialog_title)
+                .setMessage(R.string.activity_detail_no_availability_dialog_message)
+                .setPositiveButton(android.R.string.ok, null)
+                .show();
+    }
+
+    private interface ActivityUpdateCallback {
+        void onSuccess();
+
+        void onFailure(Exception e);
+    }
+
+    static class BookingItem {
+        String id;
+        String roomName;
+        String roomImageUrl;
+        String status;
+        Date checkIn;
+        Date checkOut;
+        Double totalAmount;
+        String kind;
+        int participants;
+        String activityId;
+        Double pricePerPerson;
 
         static BookingItem from(DocumentSnapshot d) {
             BookingItem i = new BookingItem();
             i.id = d.getId();
             String kind = d.getString("kind");
-            if ("ACTIVITY".equals(kind)) {
-                i.roomName = d.getString("activityName"); // reuse field for display title
+            i.kind = kind != null ? kind : "ROOM";
+            if ("ACTIVITY".equals(i.kind)) {
+                i.roomName = d.getString("activityName");
                 i.roomImageUrl = d.getString("activityImageUrl");
                 i.totalAmount = d.getDouble("totalAmount");
                 Timestamp start = d.getTimestamp("scheduleStart");
                 i.checkIn = start != null ? start.toDate() : null;
                 i.checkOut = null;
                 i.status = d.getString("status");
+                i.activityId = d.getString("activityId");
+                Long participants = d.getLong("participants");
+                i.participants = participants != null ? participants.intValue() : 0;
+                Double priceAtBooking = d.getDouble("priceAtBooking");
+                if (priceAtBooking != null) {
+                    i.pricePerPerson = priceAtBooking;
+                } else if (i.totalAmount != null && i.participants > 0) {
+                    i.pricePerPerson = i.totalAmount / i.participants;
+                } else {
+                    i.pricePerPerson = null;
+                }
             } else {
-                // ROOM
                 i.roomName = d.getString("roomName");
                 i.roomImageUrl = d.getString("roomImageUrl");
                 i.totalAmount = d.getDouble("totalAmount");
@@ -133,36 +437,94 @@ public class BookingsFragment extends Fragment {
                 i.checkIn = ci != null ? ci.toDate() : null;
                 i.checkOut = co != null ? co.toDate() : null;
                 i.status = d.getString("status");
+                i.activityId = null;
+                i.participants = 0;
+                i.pricePerPerson = null;
             }
             return i;
         }
     }
 
     static class BookingAdapter extends RecyclerView.Adapter<VH> {
+        interface OnBookingActionListener {
+            void onEditActivity(@NonNull BookingItem item);
+
+            void onDeleteActivity(@NonNull BookingItem item);
+        }
+
         private final List<BookingItem> data = new ArrayList<>();
         private final SimpleDateFormat fmt = new SimpleDateFormat("dd MMM", Locale.getDefault());
-        void submit(List<BookingItem> items) {
-            data.clear(); data.addAll(items); notifyDataSetChanged();
+        private final OnBookingActionListener listener;
+
+        BookingAdapter(OnBookingActionListener listener) {
+            this.listener = listener;
         }
-        @NonNull @Override public VH onCreateViewHolder(@NonNull ViewGroup p, int vt) {
-            View v = LayoutInflater.from(p.getContext()).inflate(R.layout.item_booking, p, false);
+
+        void submit(List<BookingItem> items) {
+            data.clear();
+            data.addAll(items);
+            notifyDataSetChanged();
+        }
+
+        @NonNull
+        @Override
+        public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_booking, parent, false);
             return new VH(v);
         }
-        @Override public void onBindViewHolder(@NonNull VH h, int pos) {
-            BookingItem b = data.get(pos);
-            h.name.setText(b.roomName);
-            String dates = (b.checkIn != null && b.checkOut != null)
-                    ? fmt.format(b.checkIn) + " → " + fmt.format(b.checkOut) : "";
-            h.dates.setText(dates);
-            h.total.setText(String.format(Locale.getDefault(),"Total: LKR %.0f", b.totalAmount == null ? 0.0 : b.totalAmount));
-            h.status.setText(b.status != null ? b.status : "");
-            Glide.with(h.img.getContext()).load(b.roomImageUrl).into(h.img);
+
+        @Override
+        public void onBindViewHolder(@NonNull VH holder, int position) {
+            BookingItem b = data.get(position);
+            holder.name.setText(b.roomName);
+            String dates;
+            if (b.checkIn != null && b.checkOut != null) {
+                dates = fmt.format(b.checkIn) + " → " + fmt.format(b.checkOut);
+            } else if (b.checkIn != null) {
+                dates = fmt.format(b.checkIn);
+            } else {
+                dates = "";
+            }
+            holder.dates.setText(dates);
+            holder.total.setText(String.format(Locale.getDefault(), "Total: LKR %.0f", b.totalAmount == null ? 0.0 : b.totalAmount));
+            holder.status.setText(b.status != null ? b.status : "");
+            Glide.with(holder.img.getContext()).load(b.roomImageUrl).into(holder.img);
+
+            if ("ACTIVITY".equals(b.kind)) {
+                holder.actions.setVisibility(View.VISIBLE);
+                holder.btnEdit.setOnClickListener(v -> {
+                    if (listener != null) {
+                        listener.onEditActivity(b);
+                    }
+                });
+                holder.btnDelete.setOnClickListener(v -> {
+                    if (listener != null) {
+                        listener.onDeleteActivity(b);
+                    }
+                });
+            } else {
+                holder.actions.setVisibility(View.GONE);
+                holder.btnEdit.setOnClickListener(null);
+                holder.btnDelete.setOnClickListener(null);
+            }
         }
-        @Override public int getItemCount() { return data.size(); }
+
+        @Override
+        public int getItemCount() {
+            return data.size();
+        }
     }
 
     static class VH extends RecyclerView.ViewHolder {
-        ImageView img; TextView name, dates, total, status;
+        ImageView img;
+        TextView name;
+        TextView dates;
+        TextView total;
+        TextView status;
+        View actions;
+        MaterialButton btnEdit;
+        MaterialButton btnDelete;
+
         VH(@NonNull View v) {
             super(v);
             img = v.findViewById(R.id.img);
@@ -170,6 +532,9 @@ public class BookingsFragment extends Fragment {
             dates = v.findViewById(R.id.tvDates);
             total = v.findViewById(R.id.tvTotal);
             status = v.findViewById(R.id.tvStatus);
+            actions = v.findViewById(R.id.containerActions);
+            btnEdit = v.findViewById(R.id.btnEdit);
+            btnDelete = v.findViewById(R.id.btnDelete);
         }
     }
 }

--- a/app/src/main/res/layout/dialog_update_activity_booking.xml
+++ b/app/src/main/res/layout/dialog_update_activity_booking.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tvDialogTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textStyle="bold"
+            android:textColor="@android:color/black"
+            android:text="@string/booking_activity_update_dialog_title"/>
+
+        <TextView
+            android:id="@+id/tvDialogSubtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/booking_activity_update_dialog_subtitle"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:textColor="#555555"/>
+
+        <TextView
+            android:id="@+id/tvSelectedDateLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/booking_activity_update_selected_date_label"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:textColor="#555555"/>
+
+        <TextView
+            android:id="@+id/tvSelectedDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+            android:textStyle="bold"
+            android:text="--"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnPickDate"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/booking_activity_update_pick_date"
+            android:textAllCaps="false"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilParticipants"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:boxBackgroundMode="outline"
+            app:boxStrokeColor="@color/green_primary"
+            app:hintEnabled="true"
+            app:hintTextColor="@color/green_primary"
+            android:hint="@string/booking_activity_update_participants_hint">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/etParticipants"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:maxLines="1"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progressUpdate"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="20dp"
+            android:visibility="gone"/>
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/item_booking.xml
+++ b/app/src/main/res/layout/item_booking.xml
@@ -48,6 +48,37 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"/>
+
+            <LinearLayout
+                android:id="@+id/containerActions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layout_marginTop="8dp"
+                android:visibility="gone">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnEdit"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minWidth="0dp"
+                    android:paddingStart="0dp"
+                    android:paddingEnd="0dp"
+                    android:textAllCaps="false"
+                    android:text="@string/booking_action_edit"/>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnDelete"
+                    style="@style/Widget.MaterialComponents.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minWidth="0dp"
+                    android:paddingStart="16dp"
+                    android:paddingEnd="0dp"
+                    android:textAllCaps="false"
+                    android:text="@string/booking_action_delete"/>
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,20 @@
 
     <string name="bookings">My Bookings</string>
     <string name="bookings_desc">Rooms and activities</string>
+    <string name="booking_action_edit">Edit reservation</string>
+    <string name="booking_action_delete">Cancel reservation</string>
+    <string name="booking_activity_update_dialog_title">Update your reservation</string>
+    <string name="booking_activity_update_dialog_subtitle">Change the date or number of participants for this activity.</string>
+    <string name="booking_activity_update_selected_date_label">Scheduled date</string>
+    <string name="booking_activity_update_pick_date">Change date</string>
+    <string name="booking_activity_update_participants_hint">Participants</string>
+    <string name="booking_activity_update_positive">Save changes</string>
+    <string name="booking_activity_update_success">Reservation updated.</string>
+    <string name="booking_activity_delete_confirm_title">Cancel this activity?</string>
+    <string name="booking_activity_delete_confirm_message">This will cancel your activity reservation. You can book it again later if there is availability.</string>
+    <string name="booking_activity_delete_success">Reservation cancelled.</string>
+    <string name="booking_activity_update_validation_date">Select a date to continue.</string>
+    <string name="booking_activity_update_validation_participants">Enter how many guests will join.</string>
 
     <string name="eco_list_title">Eco Highlights</string>
     <string name="eco_list_subtitle">Explore how we nurture the islands biodiversity and champion sustainable travel.</string>


### PR DESCRIPTION
## Summary
- add edit and cancel controls for activity reservations in the bookings list
- implement dialog to change activity reservation date or participant count with availability checks
- create supporting layout and strings for the new management experience

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e67c4669c48321adac05efa6bbfc5b