### PR TITLE
Improve hero image scrim for detail screens

### DIFF
--- a/app/src/main/res/drawable/hero_scrim.xml
+++ b/app/src/main/res/drawable/hero_scrim.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:startColor="#00000000"
-        android:centerColor="#40000000"
-        android:endColor="#80000000"
+        android:startColor="#CC000000"
+        android:centerColor="#66000000"
+        android:endColor="#00000000"
         android:angle="270"/>
 </shape>


### PR DESCRIPTION
## Summary
- darken the shared hero image scrim so that top app bar content stays legible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6993cb3a88321b24014cab6d18792