### PR TITLE
Align detail navigation icon tint with toolbar text

### DIFF
--- a/app/src/main/res/drawable/hero_scrim.xml
+++ b/app/src/main/res/drawable/hero_scrim.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <gradient
-        android:startColor="#00000000"
-        android:centerColor="#40000000"
-        android:endColor="#80000000"
+        android:startColor="#CC000000"
+        android:centerColor="#66000000"
+        android:endColor="#00000000"
         android:angle="270"/>
 </shape>

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -35,6 +35,8 @@
                 android:background="@android:color/transparent"
                 android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
                 app:navigationIcon="@drawable/baseline_arrow_back_24"
+                app:navigationIconTint="?attr/colorOnPrimary"
+                app:titleTextColor="?attr/colorOnPrimary"
                 app:title="" />
         </FrameLayout>
 

--- a/app/src/main/res/layout/activity_eco_info_detail.xml
+++ b/app/src/main/res/layout/activity_eco_info_detail.xml
@@ -35,6 +35,8 @@
                 android:background="@android:color/transparent"
                 android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
                 app:navigationIcon="@drawable/baseline_arrow_back_24"
+                app:navigationIconTint="?attr/colorOnPrimary"
+                app:titleTextColor="?attr/colorOnPrimary"
                 app:title="" />
         </FrameLayout>
 

--- a/app/src/main/res/layout/activity_room_detail.xml
+++ b/app/src/main/res/layout/activity_room_detail.xml
@@ -35,6 +35,8 @@
                 android:background="@android:color/transparent"
                 android:theme="@style/ThemeOverlay.MaterialComponents.Dark.ActionBar"
                 app:navigationIcon="@drawable/baseline_arrow_back_24"
+                app:navigationIconTint="?attr/colorOnPrimary"
+                app:titleTextColor="?attr/colorOnPrimary"
                 app:title="" />
         </FrameLayout>
 


### PR DESCRIPTION
## Summary
- darken the shared hero image scrim so that top app bar content stays legible
- tint the back navigation icons on detail screens to match the toolbar title color

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6993cb3a88321b24014cab6d18792